### PR TITLE
Add svg mime type.

### DIFF
--- a/Unosquare.Labs.EmbedIO/Modules/StaticFilesModule.cs
+++ b/Unosquare.Labs.EmbedIO/Modules/StaticFilesModule.cs
@@ -712,6 +712,7 @@
                 {".sv4cpio", "application/x-sv4cpio"},
                 {".sv4crc", "application/x-sv4crc"},
                 {".svc", "application/xml"},
+                {".svg", "image/svg+xml"},
                 {".swf", "application/x-shockwave-flash"},
                 {".t", "application/x-troff"},
                 {".tar", "application/x-tar"},


### PR DESCRIPTION
Adding svg mime type to prevent svgs being delivered as text/plain xml and displayed properly.