### PR TITLE
Fixed cancellation of task returned by RunAsync

### DIFF
--- a/Unosquare.Labs.EmbedIO/WebServer.cs
+++ b/Unosquare.Labs.EmbedIO/WebServer.cs
@@ -359,7 +359,7 @@
 
             return false;
         }
-
+   
         /// <summary>
         /// Starts the listener and the registered modules
         /// </summary>
@@ -458,8 +458,7 @@
             // free managed resources
             if (this.Listener != null)
             {
-                this.Listener.Stop();
-                this.Listener.Close();
+                ((IDisposable) this.Listener).Dispose();
                 this.Listener = null;
                 Log.Info("Listener Closed.");
             }

--- a/Unosquare.Labs.EmbedIO/WebServer.cs
+++ b/Unosquare.Labs.EmbedIO/WebServer.cs
@@ -377,7 +377,7 @@
             this.Listener.Start();
 
             this.Log.Info("Started HTTP Listener");
-            this._listenerTask = Task.Factory.StartNew(async () =>
+            this._listenerTask = Task.Run(async () =>
             {
                 while (this.Listener != null && this.Listener.IsListening)
                 {

--- a/Unosquare.Labs.EmbedIO/WebServer.cs
+++ b/Unosquare.Labs.EmbedIO/WebServer.cs
@@ -462,11 +462,6 @@
                 this.Listener = null;
                 Log.Info("Listener Closed.");
             }
-
-            if (_listenerTask != null)
-            {
-                _listenerTask.Dispose();
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
The task returned from Task.Factory.StartNew completes as soon as it hits await keyword, making the cancellation token useless, so the webServer.dispose method in the "Fluent Example"' from the readme is never called.

Changed to Task.Run, since this returns the entire task, and works as expected with the example.