### PR TITLE
Add a target to .NET Standard 1.6

### DIFF
--- a/src/Unosquare.Labs.EmbedIO.Samples/Program.cs
+++ b/src/Unosquare.Labs.EmbedIO.Samples/Program.cs
@@ -88,7 +88,7 @@
 
                 // Fire up the browser to show the content!
 #if DEBUG
-#if !NETCOREAPP1_0
+#if !NETCOREAPP1_0 && !NETSTANDARD1_6
                 var browser = new System.Diagnostics.Process()
                 {
                     StartInfo = new System.Diagnostics.ProcessStartInfo(url)

--- a/src/Unosquare.Labs.EmbedIO.Samples/WebSocketsSample.cs
+++ b/src/Unosquare.Labs.EmbedIO.Samples/WebSocketsSample.cs
@@ -166,7 +166,7 @@
                 StartInfo = new ProcessStartInfo()
                 {
                     CreateNoWindow = true,
-#if !NETCOREAPP1_0
+#if !NETCOREAPP1_0 && !NETSTANDARD1_6
                     ErrorDialog = false,
 #endif
                     FileName = "cmd.exe",

--- a/src/Unosquare.Labs.EmbedIO/Constants.cs
+++ b/src/Unosquare.Labs.EmbedIO/Constants.cs
@@ -25,7 +25,7 @@ namespace Unosquare.Labs.EmbedIO
         /// The format culture used for header outputs
         /// </summary>
         public static readonly CultureInfo StandardCultureInfo =
-#if !NETCOREAPP1_0
+#if !NETCOREAPP1_0 && !NETSTANDARD1_6 && !NETSTANDARD1_6
             CultureInfo.CreateSpecificCulture("en-US");
 #else
             new CultureInfo("en-US");
@@ -35,7 +35,7 @@ namespace Unosquare.Labs.EmbedIO
         /// The standard string comparer
         /// </summary>
         public static StringComparer StandardStringComparer =
-#if !NETCOREAPP1_0
+#if !NETCOREAPP1_0 && !NETSTANDARD1_6 && !NETSTANDARD1_6
             StringComparer.InvariantCultureIgnoreCase;
 #else
             StringComparer.OrdinalIgnoreCase;
@@ -45,7 +45,7 @@ namespace Unosquare.Labs.EmbedIO
         /// The default encoding
         /// </summary>
         public static Encoding DefaultEncoding =
-#if !NETCOREAPP1_0
+#if !NETCOREAPP1_0 && !NETSTANDARD1_6 && !NETSTANDARD1_6
             Encoding.Default;
 #else
             Encoding.GetEncoding(0);

--- a/src/Unosquare.Labs.EmbedIO/Extensions.cs
+++ b/src/Unosquare.Labs.EmbedIO/Extensions.cs
@@ -526,7 +526,7 @@
         public static string ComputeMd5Hash(Stream stream)
         {
             var md5 = MD5.Create();
-#if !NETCOREAPP1_0
+#if !NETCOREAPP1_0 && !NETSTANDARD1_6 && !NETSTANDARD1_6
             const int bufferSize = 4096;
 
             var readAheadBuffer = new byte[bufferSize];

--- a/src/Unosquare.Labs.EmbedIO/Extensions.cs
+++ b/src/Unosquare.Labs.EmbedIO/Extensions.cs
@@ -526,7 +526,7 @@
         public static string ComputeMd5Hash(Stream stream)
         {
             var md5 = MD5.Create();
-#if !NETCOREAPP1_0 && !NETSTANDARD1_6 && !NETSTANDARD1_6
+#if !NETCOREAPP1_0 && !NETSTANDARD1_6
             const int bufferSize = 4096;
 
             var readAheadBuffer = new byte[bufferSize];

--- a/src/Unosquare.Labs.EmbedIO/Modules/StaticFilesModule.cs
+++ b/src/Unosquare.Labs.EmbedIO/Modules/StaticFilesModule.cs
@@ -332,7 +332,7 @@
             }
             finally
             {
-#if !NETCOREAPP1_0
+#if !NETCOREAPP1_0 && !NETSTANDARD1_6
                 buffer.Close();
 #endif
                 buffer.Dispose();

--- a/src/Unosquare.Labs.EmbedIO/System.Net/CookieCollection.cs
+++ b/src/Unosquare.Labs.EmbedIO/System.Net/CookieCollection.cs
@@ -524,11 +524,15 @@ namespace Unosquare.Net
             if (array.Length - index < _list.Count)
                 throw new ArgumentException(
                     "The number of elements in this collection is greater than the available space of the destination array.");
-
+#if NETSTANDARD1_6
+            if (!array.GetType().GetElementType().GetTypeInfo().IsAssignableFrom(typeof(Cookie)))
+                throw new InvalidCastException(
+                    "The elements in this collection cannot be cast automatically to the type of the destination array.");
+#else
             if (!array.GetType().GetElementType().IsAssignableFrom(typeof(Cookie)))
                 throw new InvalidCastException(
                     "The elements in this collection cannot be cast automatically to the type of the destination array.");
-
+#endif
             ((IList) _list).CopyTo(array, index);
         }
 
@@ -580,7 +584,7 @@ namespace Unosquare.Net
             return _list.GetEnumerator();
         }
 
-        #endregion
+#endregion
     }
 }
 

--- a/src/Unosquare.Labs.EmbedIO/System.Net/SystemUri.cs
+++ b/src/Unosquare.Labs.EmbedIO/System.Net/SystemUri.cs
@@ -1,7 +1,8 @@
-﻿#if NETCOREAPP1_0
+﻿#if NETCOREAPP1_0 || NETSTANDARD1_6
 namespace System
 {
-    public enum UriPartial{
+    public enum UriPartial
+    {
         Scheme, Authority, Path
     }
 }

--- a/src/Unosquare.Labs.EmbedIO/WebServer.cs
+++ b/src/Unosquare.Labs.EmbedIO/WebServer.cs
@@ -352,7 +352,7 @@
                         module.Server = this;
 
                     // Log the module and hanlder to be called and invoke as a callback.
-#if !NETCOREAPP1_0
+#if !NETCOREAPP1_0 && !NETSTANDARD1_6
                     Log.DebugFormat("{0}::{1}.{2}", module.Name, callback.Method.DeclaringType.Name,
                         callback.Method.Name);
 #endif

--- a/src/Unosquare.Labs.EmbedIO/project.json
+++ b/src/Unosquare.Labs.EmbedIO/project.json
@@ -16,18 +16,35 @@
           "type": "platform",
           "version": "1.0.1"
         },
-        "System.Security.Cryptography.Primitives": "4.0.0",
-        "System.Net.Primitives": "4.0.11",
-        "System.Collections.Specialized": "4.0.1",
-        "System.Collections.NonGeneric": "4.0.1",
-        "System.Security.Claims": "4.0.1"
+        "System.Security.Cryptography.Primitives": "4.3.0",
+        "System.Net.Primitives": "4.3.0",
+        "System.Collections.Specialized": "4.3.0",
+        "System.Collections.NonGeneric": "4.3.0",
+        "System.Security.Claims": "4.3.0"
+      }
+    },
+    "netstandard1.6": {
+      "dependencies" : {
+       "NETStandard.Library": "1.6.1",
+        "System.Security.Cryptography.Primitives": "4.3.0",
+        "System.Net.Primitives": "4.3.0",
+        "System.Net.Requests": "4.3.0",
+        "System.Collections.Specialized": "4.3.0",
+        "System.Collections.NonGeneric": "4.3.0",
+        "System.Security.Claims": "4.3.0",
+        "System.Net.Security": "4.3.0",
+        "System.Net.NameResolution": "4.3.0",
+        "System.Threading.Thread": "4.3.0",
+        "System.Threading.ThreadPool": "4.3.0",
+        "System.IO.FileSystem.Watcher": "4.3.0"
       }
     },
     "net452": {
 
     },
     "net46": {
-
+      "dependencies": {
+      }
     }
   },
   "runtimes": {

--- a/src/Unosquare.Labs.EmbedIO/project.json
+++ b/src/Unosquare.Labs.EmbedIO/project.json
@@ -16,11 +16,11 @@
           "type": "platform",
           "version": "1.0.1"
         },
-        "System.Security.Cryptography.Primitives": "4.3.0",
-        "System.Net.Primitives": "4.3.0",
-        "System.Collections.Specialized": "4.3.0",
-        "System.Collections.NonGeneric": "4.3.0",
-        "System.Security.Claims": "4.3.0"
+        "System.Security.Cryptography.Primitives": "4.0.0",
+        "System.Net.Primitives": "4.0.11",
+        "System.Collections.Specialized": "4.0.1",
+        "System.Collections.NonGeneric": "4.0.1",
+        "System.Security.Claims": "4.0.1"
       }
     },
     "netstandard1.6": {

--- a/test/Unosquare.Labs.EmbedIO.Tests/FluentTest.cs
+++ b/test/Unosquare.Labs.EmbedIO.Tests/FluentTest.cs
@@ -19,7 +19,7 @@
             RootPath = TestHelper.SetupStaticFolder();
         }
 
-#if !NETCOREAPP1_0
+#if !NETCOREAPP1_0 && !NETSTANDARD1_6
         [Test]
         public void FluentWithStaticFolder()
         {

--- a/test/Unosquare.Labs.EmbedIO.Tests/StaticFilesModuleTest.cs
+++ b/test/Unosquare.Labs.EmbedIO.Tests/StaticFilesModuleTest.cs
@@ -109,7 +109,7 @@
             Assert.Fail("The Exception should raise");
         }
 
-#if !NETCOREAPP1_0
+#if !NETCOREAPP1_0 && !NETSTANDARD1_6
         [Test]
         public void GetInitialPartial()
         {
@@ -277,7 +277,7 @@
             }
         }
 
-#if !NETCOREAPP1_0
+#if !NETCOREAPP1_0 && !NETSTANDARD1_6
         [Test]
         public async Task GetGzipCompressFile()
         {

--- a/test/Unosquare.Labs.EmbedIO.Tests/WebServerCultureTest.cs
+++ b/test/Unosquare.Labs.EmbedIO.Tests/WebServerCultureTest.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP1_0
+﻿#if !NETCOREAPP1_0 && !NETSTANDARD1_6
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/test/Unosquare.Labs.EmbedIO.Tests/WebSocketsModuleTest.cs
+++ b/test/Unosquare.Labs.EmbedIO.Tests/WebSocketsModuleTest.cs
@@ -1,7 +1,7 @@
 ﻿namespace Unosquare.Labs.EmbedIO.Tests
 {
     using System;
-#if !NETCOREAPP1_0
+#if !NETCOREAPP1_0 && !NETSTANDARD1_6
     using System.Net.WebSockets;
 #endif
     using System.Threading;
@@ -31,7 +31,7 @@
 
             Assert.AreEqual(WebServer.Module<WebSocketsModule>().Handlers.Count, 1, "WebSocketModule has one handler");
 
-#if !NETCOREAPP1_0
+#if !NETCOREAPP1_0 && !NETSTANDARD1_6
             var clientSocket = new ClientWebSocket();
             var ct = new CancellationTokenSource();
             await clientSocket.ConnectAsync(new Uri(Resources.WsServerAddress + "test"), ct.Token);


### PR DESCRIPTION
This pull request adds a target to .NET Standard 1.6, opening up the possibilty of cross-platform between .NET Core and .NET Framework. 