### PR TITLE
Add or Update a key in the SessionInfo

### DIFF
--- a/src/Unosquare.Labs.EmbedIO/SessionInfo.cs
+++ b/src/Unosquare.Labs.EmbedIO/SessionInfo.cs
@@ -46,7 +46,7 @@
             get { return (Data.ContainsKey(key)) ? Data[key] : null; }
             set { 
                 if (Data.ContainsKey(key)) {
-                    Data.TryUpdate(key, value);
+                    Data.TryUpdate(key, value, value);
                 }
                 else {
                     Data.TryAdd(key, value);

--- a/src/Unosquare.Labs.EmbedIO/SessionInfo.cs
+++ b/src/Unosquare.Labs.EmbedIO/SessionInfo.cs
@@ -44,7 +44,15 @@
         public object this[string key]
         {
             get { return (Data.ContainsKey(key)) ? Data[key] : null; }
-            set { Data.TryAdd(key, value); }
+            set { 
+                if (Data.ContainsKey(key)) {
+                    Data.TryUpdate(key, value);
+                }
+                else {
+                    Data.TryAdd(key, value);
+                }
+            }
         }
+        
     }
 }


### PR DESCRIPTION
Currently, SessionInfo.Data[] only supports adding a key. With this patch, updating is now possible.

Arf, error in the patch. I've forgotten the third parameter of TryUpdate(). Excuse me.