### PR TITLE
Fix Exception thrown by BearerTokenModule when using "WWW-Authenticate" header

### DIFF
--- a/src/Unosquare.Labs.EmbedIO/System.Net/WebHeaderCollection.cs
+++ b/src/Unosquare.Labs.EmbedIO/System.Net/WebHeaderCollection.cs
@@ -507,7 +507,7 @@ namespace Unosquare.Net
                         "WwwAuthenticate",
                         new HttpHeaderInfo(
                             "WWW-Authenticate",
-                            HttpHeaderType.Response | HttpHeaderType.Restricted | HttpHeaderType.MultiValue)
+                            HttpHeaderType.Response | HttpHeaderType.MultiValue)
                     }
                 };
         }


### PR DESCRIPTION
Hi,

This patch change the `WWW-Authenticate` header to not restricted.

In fact, the BearerTokenModule Extension method `Rejected()` throw exception  "This header must be modified with the appropriate property." when request is not valid (invalid token).

Thanks