### PR TITLE
Add Encoding property to WebSocketsServer

### DIFF
--- a/src/Unosquare.Labs.EmbedIO/Modules/WebSocketsModule.cs
+++ b/src/Unosquare.Labs.EmbedIO/Modules/WebSocketsModule.cs
@@ -225,6 +225,14 @@
         /// The name of the server.
         /// </value>
         public abstract string ServerName { get; }
+        
+        /// <summary>
+        /// Gets the Encoding used to use the Send method to send a string. The default is UTF8 per the WebSocket specification.
+        /// </summary>
+        /// <value>
+        /// The Encoding to be used.
+        /// </value>
+        protected Encoding Encoding { get; set; } = System.Text.Encoding.UTF8;
 
         /// <summary>
         /// Accepts the WebSocket connection.
@@ -373,7 +381,7 @@
             try
             {
                 if (payload == null) payload = string.Empty;
-                var buffer = System.Text.Encoding.UTF8.GetBytes(payload);
+                var buffer = Encoding.GetBytes(payload);
 
 #if NET47
                 await webSocket.WebSocket.SendAsync(

--- a/src/Unosquare.Labs.EmbedIO/Modules/WebSocketsModule.cs
+++ b/src/Unosquare.Labs.EmbedIO/Modules/WebSocketsModule.cs
@@ -232,7 +232,7 @@
         /// <value>
         /// The Encoding to be used.
         /// </value>
-        protected Encoding Encoding { get; set; } = System.Text.Encoding.UTF8;
+        protected System.Text.Encoding Encoding { get; set; } = System.Text.Encoding.UTF8;
 
         /// <summary>
         /// Accepts the WebSocket connection.


### PR DESCRIPTION
Add an Encoding property to the WebSocketsServer class, which inherited classes can use to decode the incoming byte[] to string in OnMessageReceived and OnFrameReceived.

The justification is that without this property, every implementation which deals with strings being received needs to define their own UTF8 encoding, while the WebSocket standard specifies that UTF8 must (should?) be used. It's convenient to have this encoding ready in the base class, so the programmer doesn't have to know or look up which encoding is used.

This also adds a protected setter just in case some library client wants to be dealing with non-UTF8 encoded strings and wants to use the Send method. The main justification is not defining UTF8 encoding twice, so imo the setter can be removed until someone has a valid use case for that.