### PR TITLE
Add .Net Standard 2.0 support

### DIFF
--- a/src/Unosquare.Labs.EmbedIO/Unosquare.Labs.EmbedIO.csproj
+++ b/src/Unosquare.Labs.EmbedIO/Unosquare.Labs.EmbedIO.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>EmbedIO Web Server</AssemblyTitle>
     <VersionPrefix>1.7.1</VersionPrefix>
     <Authors>Mario Di Vece;Geovanni Perez</Authors>
-    <TargetFrameworks>uap10.0;netstandard1.6;netstandard1.3;net46;net462</TargetFrameworks>
+    <TargetFrameworks>uap10.0;netstandard1.6;netstandard1.3;net46;net462;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Unosquare.Labs.EmbedIO</AssemblyName>
     <PackageId>Unosquare.Labs.EmbedIO</PackageId>
@@ -67,5 +67,7 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <DefineConstants>$(DefineConstants);NET47</DefineConstants>
   </PropertyGroup>
-
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);NET47</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/test/Unosquare.Labs.EmbedIO.Tests/Unosquare.Labs.EmbedIO.Tests.csproj
+++ b/test/Unosquare.Labs.EmbedIO.Tests/Unosquare.Labs.EmbedIO.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Copyright>Copyright (c) 2016-2017 - Unosquare</Copyright>
-    <TargetFrameworks>netcoreapp1.1;net462;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net462;net46</TargetFrameworks>
     <TestProjectType>UnitTest</TestProjectType>
     <DebugType>Full</DebugType>
   </PropertyGroup>
@@ -31,6 +31,10 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <DefineConstants>$(DefineConstants);NET47</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <DefineConstants>$(DefineConstants);NET47</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
As already mentioned in #92, I need .Net Standard SSL support for my project. Luckily, the required classes were all added with .Net Standard 2.0 so they match the classes from .Net. Actually, I was amazed that it just worked, no problems at all and my project is running the library successfully.

Note: Resharper didn't want to run the unit tests of the .Net Core versions.