### PR TITLE
Add escaping of filenames in DirectoryBrowser of StaticFilesModule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ TestResult.xml
 /_api
 /tools
 /.vs/Unosquare.Labs.EmbedIO/v15/sqlite3/*
+
+# JetBrains Rider IDE folder
+.idea/

--- a/src/Unosquare.Labs.EmbedIO/Modules/StaticFilesModule.cs
+++ b/src/Unosquare.Labs.EmbedIO/Modules/StaticFilesModule.cs
@@ -290,10 +290,10 @@
             var entries = Directory.GetDirectories(localPath).Select(x => x.Replace(localPath + Path.DirectorySeparatorChar, string.Empty))
                 .Union(Directory.GetFiles(localPath, "*", SearchOption.TopDirectoryOnly).Select(Path.GetFileName))
                 .Where(x => !string.IsNullOrEmpty(x))
-                .Select(y => $"<li><a href='{y}'>{y}</a></li>");
+                .Select(y => $"<li><a href='{Uri.EscapeDataString(y)}'>{WebUtility.HtmlEncode(y)}</a></li>");
 
             var content = Responses.ResponseBaseHtml.Replace("{0}",
-                $"<h1>Directory: {context.RequestPathCaseSensitive()}</h1><ul>{string.Join(string.Empty, entries)}</ul>");
+                $"<h1>Directory: {WebUtility.HtmlEncode(context.RequestPathCaseSensitive())}</h1><ul>{string.Join(string.Empty, entries)}</ul>");
 
             return context.HtmlResponseAsync(content, cancellationToken: ct);
         }

--- a/src/Unosquare.Labs.EmbedIO/Modules/StaticFilesModule.cs
+++ b/src/Unosquare.Labs.EmbedIO/Modules/StaticFilesModule.cs
@@ -290,10 +290,10 @@
             var entries = Directory.GetDirectories(localPath).Select(x => x.Replace(localPath + Path.DirectorySeparatorChar, string.Empty))
                 .Union(Directory.GetFiles(localPath, "*", SearchOption.TopDirectoryOnly).Select(Path.GetFileName))
                 .Where(x => !string.IsNullOrEmpty(x))
-                .Select(y => $"<li><a href='{Uri.EscapeDataString(y)}'>{WebUtility.HtmlEncode(y)}</a></li>");
+                .Select(y => $"<li><a href='{Uri.EscapeDataString(y)}'>{System.Net.WebUtility.HtmlEncode(y)}</a></li>");
 
             var content = Responses.ResponseBaseHtml.Replace("{0}",
-                $"<h1>Directory: {WebUtility.HtmlEncode(context.RequestPathCaseSensitive())}</h1><ul>{string.Join(string.Empty, entries)}</ul>");
+                $"<h1>Directory: {System.Net.WebUtility.HtmlEncode(context.RequestPathCaseSensitive())}</h1><ul>{string.Join(string.Empty, entries)}</ul>");
 
             return context.HtmlResponseAsync(content, cancellationToken: ct);
         }


### PR DESCRIPTION
Current realization are vulnerable to XSS with filenames like `<b>smth`, `'>Hi<a href='omg`