### PR TITLE
Stricter RegEx filtering to prevent incorrect routing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,7 +167,7 @@ TestResult.xml
 /_site
 /_api
 /tools
-/.vs/Unosquare.Labs.EmbedIO/v15/sqlite3/*
+/.vs/*
 
 # JetBrains Rider IDE folder
 .idea/

--- a/src/Unosquare.Labs.EmbedIO/Extensions.cs
+++ b/src/Unosquare.Labs.EmbedIO/Extensions.cs
@@ -27,7 +27,8 @@
     {
         #region Constants
 
-        private const string RegexRouteReplace = "(.*)";
+        private const string RegexRouteReplace = "([^//]*)";
+        private const string WildcardRouteReplace = "(.*)";
 
         private static readonly byte[] LastByte = {0x00};
 
@@ -259,7 +260,7 @@
         /// <returns>The params from the request.</returns>
         public static string[] RequestWildcardUrlParams(string requestPath, string basePath)
         {
-            var match = new Regex(basePath.Replace("*", RegexRouteReplace)).Match(requestPath);
+            var match = new Regex(basePath.Replace("*", WildcardRouteReplace)).Match(requestPath);
 
             return match.Success
                 ? match.Groups[1].Value.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries)
@@ -302,7 +303,7 @@
             if (validateFunc == null) validateFunc = () => false;
             if (requestPath == basePath && !validateFunc()) return new Dictionary<string, object>();
 
-            var regex = new Regex(RouteParamRegex.Replace(basePath, RegexRouteReplace));
+            var regex = new Regex(String.Concat("^",RouteParamRegex.Replace(basePath, RegexRouteReplace),"$"));
             var match = regex.Match(requestPath);
 
             var pathParts = basePath.Split('/');

--- a/test/Unosquare.Labs.EmbedIO.Tests/FixtureBase.cs
+++ b/test/Unosquare.Labs.EmbedIO.Tests/FixtureBase.cs
@@ -43,7 +43,9 @@
         {
             using (var client = new HttpClient())
             {
-                return await client.GetStringAsync($"{WebServerUrl}{partialUrl}");
+                //Determine the absolute Uri by combining with WebServerUrl
+                Uri uri = new Uri(new Uri(WebServerUrl), partialUrl);
+                return await client.GetStringAsync(uri);
             }
         }
     }

--- a/test/Unosquare.Labs.EmbedIO.Tests/RegexRoutingTest.cs
+++ b/test/Unosquare.Labs.EmbedIO.Tests/RegexRoutingTest.cs
@@ -8,7 +8,7 @@
     public class RegexRoutingTest : FixtureBase
     {
         public RegexRoutingTest()
-            : base(ws => ws.RegisterModule(new TestRoutingModule()), Constants.RoutingStrategy.Regex)
+            : base(ws => ws.RegisterModule(new TestRegexModule()), Constants.RoutingStrategy.Regex)
         {
         }
 
@@ -33,7 +33,7 @@
             [Test]
             public async Task GetDataWithMultipleRegex()
             {
-                var call = await GetString($"{WebServerUrl}data/1/asdasda/dasdasasda");
+                var call = await GetString($"{WebServerUrl}data/1/dasdasasda");
 
                 Assert.AreEqual("dasdasasda", call);
             }

--- a/test/Unosquare.Labs.EmbedIO.Tests/TestObjects/TestRegexController.cs
+++ b/test/Unosquare.Labs.EmbedIO.Tests/TestObjects/TestRegexController.cs
@@ -22,6 +22,19 @@
             return context.JsonResponse(new {Ok = true});
         }
 
+        [WebApiHandler(HttpVerbs.Get, "/" + RelativePath + "regex")]
+        public bool GetPeople(WebServer server, HttpListenerContext context)
+        {
+            try
+            {
+                return context.JsonResponse(PeopleRepository.Database);
+            }
+            catch (Exception ex)
+            {
+                return context.JsonExceptionResponse(ex);
+            }
+        }
+
         [WebApiHandler(HttpVerbs.Get, "/" + RelativePath + "regex/{id}")]
         public bool GetPerson(WebServer server, HttpListenerContext context, int id)
         {

--- a/test/Unosquare.Labs.EmbedIO.Tests/TestObjects/TestRegexModule.cs
+++ b/test/Unosquare.Labs.EmbedIO.Tests/TestObjects/TestRegexModule.cs
@@ -7,9 +7,9 @@
     {
         public TestRegexModule()
         {
-            AddHandler("/data/{id}/", Constants.HttpVerbs.Any, (ctx, ct) =>
+            AddHandler("/data/{id}", Constants.HttpVerbs.Any, (ctx, ct) =>
             {
-                var buffer = Encoding.UTF8.GetBytes(ctx.RequestRegexUrlParams("/data/{id}/")["id"].ToString());
+                var buffer = Encoding.UTF8.GetBytes(ctx.RequestRegexUrlParams("/data/{id}")["id"].ToString());
                 ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
 
                 return Task.FromResult(true);


### PR DESCRIPTION
^ and $ anchors are used.  RegEx values now explicitly exclude the '/' character.