### PR TITLE
Enhance request logging in WebServer

### DIFF
--- a/src/Unosquare.Labs.EmbedIO/WebServer.cs
+++ b/src/Unosquare.Labs.EmbedIO/WebServer.cs
@@ -447,7 +447,7 @@
                 requestId = string.Concat(DateTime.Now.Ticks.ToString(), requestEndpoint).GetHashCode().ToString("x2");
 
                 // Log the request and its ID
-                $"Start of Request {requestId} - Source {requestEndpoint} - {context.RequestVerb().ToString().ToUpperInvariant()}: {context.RequestPath()}"
+                $"Start of Request {requestId} - Source {requestEndpoint} - {context.RequestVerb().ToString().ToUpperInvariant()}: {context.Request.Url.PathAndQuery} - {context.Request.UserAgent}"
                     .Debug(nameof(WebServer));
 
                 var processResult = await ProcessRequest(context, ct);


### PR DESCRIPTION
- add QueryString to RequestPath
- add UserAgent

with this extras data, we can now write an access/error log like other webserver. With a very few line of code (using Terminal.OnLogMessageReceived and StreamWriter() on it).