### PR TITLE
added link do 1.x branch in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 *:star: Please star this project if you find it useful!*
 
+**This README is for EmbedIO v2.x. Click [here](https://github.com/unosquare/embedio/tree/v1.X) if you are using EmbedIO v1.x.**
+
 
 - [Overview](#overview)
     - [Some usage scenarios](#some-usage-scenarios)


### PR DESCRIPTION
I added link to 1.x branch, because it was confusing that docs didn't match latest stable version from NuGet