### PR TITLE
Fix error 403 on virtual paths (#263)

### DIFF
--- a/src/Unosquare.Labs.EmbedIO/Core/VirtualPaths.cs
+++ b/src/Unosquare.Labs.EmbedIO/Core/VirtualPaths.cs
@@ -40,7 +40,9 @@
             }
 
             // Check if the requested local path is part of the root File System Path
-            if (IsPartOfPath(localPath, FileSystemPath) == false)
+            // or of any of the virtualized paths (this latter test fixes issue #263)
+            string testLocalPath = localPath;
+            if (!IsPartOfPath(localPath, FileSystemPath) && !Values.Any(vfsPath => IsPartOfPath(testLocalPath, vfsPath)))
             {
                 return VirtualPathStatus.Forbidden;
             }

--- a/test/Unosquare.Labs.EmbedIO.Tests/FixtureBase.cs
+++ b/test/Unosquare.Labs.EmbedIO.Tests/FixtureBase.cs
@@ -35,7 +35,12 @@
                 : new WebServer(WebServerUrl, _routeStrategy);
 
             _builder(WebServerInstance);
+            OnAfterInit();
             WebServerInstance.RunAsync();
+        }
+
+        protected virtual void OnAfterInit()
+        {
         }
 
         [TearDown]

--- a/test/Unosquare.Labs.EmbedIO.Tests/TestObjects/TestHelper.cs
+++ b/test/Unosquare.Labs.EmbedIO.Tests/TestObjects/TestHelper.cs
@@ -20,20 +20,20 @@
 
         private const string Placeholder = "This is a placeholder";
 
-        public static string RootPath()
+        public static string RootPath(string folderName)
         {
             var assemblyPath = Path.GetDirectoryName(typeof(StaticFilesModuleTest).GetTypeInfo().Assembly.Location);
-            return Path.Combine(assemblyPath ?? throw new InvalidOperationException(), "html");
+            return Path.Combine(assemblyPath ?? throw new InvalidOperationException(), folderName);
         }
+
+        public static string RootPath() => RootPath("html");
 
         public static byte[] GetBigData() => File.Exists(Path.Combine(RootPath(), BigDataFile))
             ? File.ReadAllBytes(Path.Combine(RootPath(), BigDataFile))
             : null;
 
-        public static string SetupStaticFolder(bool onlyIndex = true)
+        private static string SetupStaticFolderCore(string rootPath, bool onlyIndex = true)
         {
-            var rootPath = RootPath();
-
             if (Directory.Exists(rootPath) == false)
                 Directory.CreateDirectory(rootPath);
 
@@ -69,6 +69,10 @@
 
             return rootPath;
         }
+
+        public static string SetupStaticFolder(bool onlyIndex = true) => SetupStaticFolderCore(RootPath(), onlyIndex);
+
+        public static string SetupStaticFolder(string folderName, bool onlyIndex = true) => SetupStaticFolderCore(RootPath(folderName), onlyIndex);
 
         public static string GetStaticFolderInstanceIndexFileContents(string instanceName) =>
             string.IsNullOrWhiteSpace(instanceName)


### PR DESCRIPTION
The fix itself was proposed by @developerFlo in #263. I just added a unit test.

The other changes are to make test fixtures (especially `StaticFilesModuleTest`) a bit more flexible so I could use existing code to initialize the virtualized directory.