### PR TITLE
Automatically dispose web modules if they implement IDisposable.

### DIFF
--- a/src/Unosquare.Labs.EmbedIO/WebServer.cs
+++ b/src/Unosquare.Labs.EmbedIO/WebServer.cs
@@ -203,7 +203,7 @@
         public List<string> UrlPrefixes => Listener.Prefixes;
 
         /// <inheritdoc />
-        public ReadOnlyCollection<IWebModule> Modules => _modules.AsReadOnly();
+        public ReadOnlyCollection<IWebModule> Modules => _modules.Modules;
 
         /// <inheritdoc />
         public ISessionWebModule SessionModule => _modules.SessionModule;
@@ -268,11 +268,7 @@
             try
             {
                 // Init modules
-                foreach (var module in _modules)
-                {
-                    module.Server = this;
-                    module.Start(ct);
-                }
+                _modules.StartModules(this, ct);
 
                 State = WebServerState.Listening;
 
@@ -349,6 +345,8 @@
             }
 
             "Listener Closed.".Info(nameof(WebServer));
+
+            _modules.Dispose();
         }
     }
 }

--- a/test/Unosquare.Labs.EmbedIO.Tests/EasyRoutesTest.cs
+++ b/test/Unosquare.Labs.EmbedIO.Tests/EasyRoutesTest.cs
@@ -12,117 +12,125 @@ namespace Unosquare.Labs.EmbedIO.Tests
         [Test]
         public async Task AddOnAny_ResponseOK()
         {
-            var server = new TestWebServer();
+            using (var server = new TestWebServer())
+            {
+                server
+                    .OnAny((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
 
-            server
-                .OnAny((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
+                server.RunAsync();
 
-            server.RunAsync();
-
-            Assert.AreEqual(Ok, await server.GetClient().GetAsync());
+                Assert.AreEqual(Ok, await server.GetClient().GetAsync());
+            }
         }
 
         [Test]
         public async Task AddOnGet_ResponseOK()
         {
-            var server = new TestWebServer();
+            using (var server = new TestWebServer())
+            {
+                server
+                    .OnGet((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
 
-            server
-                .OnGet((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
+                server.RunAsync();
 
-            server.RunAsync();
-
-            Assert.AreEqual(Ok, await server.GetClient().GetAsync());
+                Assert.AreEqual(Ok, await server.GetClient().GetAsync());
+            }
         }
 
         [Test]
         public async Task AddOnPost_ResponseOK()
         {
-            var server = new TestWebServer();
+            using (var server = new TestWebServer())
+            {
+                server
+                    .OnPost((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
 
-            server
-                .OnPost((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
+                server.RunAsync();
 
-            server.RunAsync();
+                var response = await server.GetClient().SendAsync(new TestHttpRequest(Constants.HttpVerbs.Post));
 
-            var response = await server.GetClient().SendAsync(new TestHttpRequest(Constants.HttpVerbs.Post));
-
-            Assert.AreEqual(Ok, response.GetBodyAsString());
+                Assert.AreEqual(Ok, response.GetBodyAsString());
+            }
         }
 
         [Test]
         public async Task AddOnPut_ResponseOK()
         {
-            var server = new TestWebServer();
+            using (var server = new TestWebServer())
+            {
+                server
+                    .OnPut((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
 
-            server
-                .OnPut((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
+                server.RunAsync();
 
-            server.RunAsync();
+                var response = await server.GetClient().SendAsync(new TestHttpRequest(Constants.HttpVerbs.Put));
 
-            var response = await server.GetClient().SendAsync(new TestHttpRequest(Constants.HttpVerbs.Put));
-
-            Assert.AreEqual(Ok, response.GetBodyAsString());
+                Assert.AreEqual(Ok, response.GetBodyAsString());
+            }
         }
 
         [Test]
         public async Task AddOnHead_ResponseOK()
         {
-            var server = new TestWebServer();
+            using (var server = new TestWebServer())
+            {
+                server
+                    .OnHead((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
 
-            server
-                .OnHead((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
+                server.RunAsync();
 
-            server.RunAsync();
+                var response = await server.GetClient().SendAsync(new TestHttpRequest(Constants.HttpVerbs.Head));
 
-            var response = await server.GetClient().SendAsync(new TestHttpRequest(Constants.HttpVerbs.Head));
-
-            Assert.AreEqual(Ok, response.GetBodyAsString());
+                Assert.AreEqual(Ok, response.GetBodyAsString());
+            }
         }
         
         [Test]
         public async Task AddOnDelete_ResponseOK()
         {
-            var server = new TestWebServer();
+            using (var server = new TestWebServer())
+            {
+                server
+                    .OnDelete((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
 
-            server
-                .OnDelete((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
+                server.RunAsync();
 
-            server.RunAsync();
+                var response = await server.GetClient().SendAsync(new TestHttpRequest(Constants.HttpVerbs.Delete));
 
-            var response = await server.GetClient().SendAsync(new TestHttpRequest(Constants.HttpVerbs.Delete));
-
-            Assert.AreEqual(Ok, response.GetBodyAsString());
+                Assert.AreEqual(Ok, response.GetBodyAsString());
+            }
         }
 
         [Test]
         public async Task AddOnOptions_ResponseOK()
         {
-            var server = new TestWebServer();
+            using (var server = new TestWebServer())
+            {
+                server
+                    .OnOptions((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
 
-            server
-                .OnOptions((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
+                server.RunAsync();
 
-            server.RunAsync();
+                var response = await server.GetClient().SendAsync(new TestHttpRequest(Constants.HttpVerbs.Options));
 
-            var response = await server.GetClient().SendAsync(new TestHttpRequest(Constants.HttpVerbs.Options));
-
-            Assert.AreEqual(Ok, response.GetBodyAsString());
+                Assert.AreEqual(Ok, response.GetBodyAsString());
+            }
         }
 
         [Test]
         public async Task AddOnPatch_ResponseOK()
         {
-            var server = new TestWebServer();
+            using (var server = new TestWebServer())
+            {
+                server
+                    .OnPatch((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
 
-            server
-                .OnPatch((ctx, ct) => ctx.StringResponseAsync(Ok, cancellationToken: ct));
+                server.RunAsync();
 
-            server.RunAsync();
+                var response = await server.GetClient().SendAsync(new TestHttpRequest(Constants.HttpVerbs.Patch));
 
-            var response = await server.GetClient().SendAsync(new TestHttpRequest(Constants.HttpVerbs.Patch));
-
-            Assert.AreEqual(Ok, response.GetBodyAsString());
+                Assert.AreEqual(Ok, response.GetBodyAsString());
+            }
         }
     }
 }

--- a/test/Unosquare.Labs.EmbedIO.Tests/FixtureBase.cs
+++ b/test/Unosquare.Labs.EmbedIO.Tests/FixtureBase.cs
@@ -7,7 +7,7 @@
     using System.Threading.Tasks;
     using TestObjects;
 
-    public abstract class FixtureBase
+    public abstract class FixtureBase : IDisposable
     {
         private readonly Action<IWebServer> _builder;
         private readonly bool _useTestWebServer;
@@ -22,9 +22,20 @@
             _useTestWebServer = useTestWebServer;
         }
 
+        ~FixtureBase()
+        {
+            Dispose(false);
+        }
+
         public string WebServerUrl { get; private set; }
 
         public IWebServer WebServerInstance { get; private set; }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
 
         [SetUp]
         public void Init()
@@ -37,6 +48,13 @@
             _builder(WebServerInstance);
             OnAfterInit();
             WebServerInstance.RunAsync();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing) return;
+
+            (WebServerInstance as IDisposable)?.Dispose();
         }
 
         protected virtual void OnAfterInit()

--- a/test/Unosquare.Labs.EmbedIO.Tests/IWebServerTest.cs
+++ b/test/Unosquare.Labs.EmbedIO.Tests/IWebServerTest.cs
@@ -11,66 +11,79 @@
         [Test]
         public void SetupInMemoryWebServer_ReturnsValidInstance()
         {
-            Assert.IsNotNull(new WebServer());
+            using (var webserver = new TestWebServer())
+            {
+                Assert.IsNotNull(webserver);
+            }
         }
 
         [Test]
         public void RegisterWebModule_ReturnsValidInstance()
         {
-            var webserver = new TestWebServer();
-            webserver.RegisterModule(new FallbackModule((ctx, ct) => ctx.JsonResponseAsync(nameof(TestWebServer), ct)));
+            using (var webserver = new TestWebServer())
+            {
+                webserver.RegisterModule(new FallbackModule((ctx, ct) => ctx.JsonResponseAsync(nameof(TestWebServer), ct)));
 
-            Assert.AreEqual(1, webserver.Modules.Count);
+                Assert.AreEqual(1, webserver.Modules.Count);
+            }
         }
 
         [Test]
         public void UnregisterWebModule_ReturnsValidInstance()
         {
-            var webserver = new TestWebServer();
-            webserver.RegisterModule(new FallbackModule((ctx, ct) => ctx.JsonResponseAsync(nameof(TestWebServer), ct)));
-            webserver.UnregisterModule(typeof(FallbackModule));
+            using (var webserver = new TestWebServer())
+            {
+                webserver.RegisterModule(new FallbackModule((ctx, ct) => ctx.JsonResponseAsync(nameof(TestWebServer), ct)));
+                webserver.UnregisterModule(typeof(FallbackModule));
 
-            Assert.AreEqual(0, webserver.Modules.Count);
+                Assert.AreEqual(0, webserver.Modules.Count);
+            }
         }
 
         [Test]
         public void RegisterSessionModule_ReturnsValidInstance()
         {
-            var webserver = new TestWebServer();
-            webserver.RegisterModule(new LocalSessionModule());
+            using (var webserver = new TestWebServer())
+            {
+                webserver.RegisterModule(new LocalSessionModule());
 
-            Assert.NotNull(webserver.SessionModule);
+                Assert.NotNull(webserver.SessionModule);
+            }
         }
 
         [Test]
         public void UnregisterSessionModule_ReturnsValidInstance()
         {
-            var webserver = new TestWebServer();
-            webserver.RegisterModule(new LocalSessionModule());
-            webserver.UnregisterModule(typeof(LocalSessionModule));
+            using (var webserver = new TestWebServer())
+            {
+                webserver.RegisterModule(new LocalSessionModule());
+                webserver.UnregisterModule(typeof(LocalSessionModule));
 
-            Assert.IsNull(webserver.SessionModule);
+                Assert.IsNull(webserver.SessionModule);
+            }
         }
 
         [Test]
         public async Task RunsServerAndRequestData_ReturnsValidData()
         {
-            var webserver = new TestWebServer();
-            webserver.OnAny((ctx, ct) => ctx.JsonResponseAsync(new Person { Name = nameof(Person) }, ct));
+            using (var webserver = new TestWebServer())
+            {
+                webserver.OnAny((ctx, ct) => ctx.JsonResponseAsync(new Person {Name = nameof(Person)}, ct));
 
 #pragma warning disable 4014
-            webserver.RunAsync();
+                webserver.RunAsync();
 #pragma warning restore 4014
 
-            var client = webserver.GetClient();
+                var client = webserver.GetClient();
 
-            var data = await client.GetAsync("/");
-            Assert.IsNotNull(data);
+                var data = await client.GetAsync("/");
+                Assert.IsNotNull(data);
 
-            var person = Json.Deserialize<Person>(data);
-            Assert.IsNotNull(person);
+                var person = Json.Deserialize<Person>(data);
+                Assert.IsNotNull(person);
 
-            Assert.AreEqual(person.Name, nameof(Person));
+                Assert.AreEqual(person.Name, nameof(Person));
+            }
         }
     }
 }


### PR DESCRIPTION
* Implement IDisposable in WebModules.

* Dispose all disposable modules in WebModules.Dispose.

* Dispose disposable modules upon unregistration.

* Make WebModules not extend List<IWebModule>, since a call to Remove would not take care of disposing a disposable module.

* Add property WebModules.Modules and method WebModules.StartModules to keep the list of modules encapsulated.

* Properly dispose the WebModules instance used by WebServer.

* [BREAKING] Add IDisposable implementation to TestWebServer to properly dispose its WebModules instance.

* Add using blocks wherever TestWebServer is used.

* Add IDisposable implementation to FixtureBase to properly dispose its WebServerInstance.