### PR TITLE
Fixes endless loop on incomplete headers

### DIFF
--- a/src/Unosquare.Labs.EmbedIO/System.Net/HttpConnection.cs
+++ b/src/Unosquare.Labs.EmbedIO/System.Net/HttpConnection.cs
@@ -182,12 +182,11 @@
             // Continue reading until full header is received.
             // Especially important for multipart requests when the second part of the header arrives after a tiny delay
             // because the web browser has to measure the content length first.
-            var parsedBytes = 0;
             while (true)
             {
                 try
                 {
-                    await _ms.WriteAsync(_buffer, parsedBytes, offset - parsedBytes).ConfigureAwait(false);
+                    await _ms.WriteAsync(_buffer, 0, offset).ConfigureAwait(false);
                     if (_ms.Length > 32768)
                     {
                         Close(true);
@@ -232,8 +231,7 @@
                     return;
                 }
 
-                parsedBytes = offset;
-                offset += await Stream.ReadAsync(_buffer, offset, BufferSize - offset).ConfigureAwait(false);
+                offset = await Stream.ReadAsync(_buffer, 0, BufferSize).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
The `OnReadInternal` method can get into an endless loop in 2 ways currently.
My two examples here will refer to the code here: https://github.com/unosquare/embedio/blob/master/src/Unosquare.Labs.EmbedIO/System.Net/HttpConnection.cs#L178-L238

1: when a header gets sent and the connection gets closed before the header was sent completely.
Simple reproduce:
```cmd
nc localhost 8877
GET / HTTP/1.1<Enter>
<Ctrl+C>
```

In this case `offset` will be `15` so the `if (offset == 0)` will never be true, and `offset += await Stream.ReadAsync` will always add 0 as the Stream has been closed.


2: When the header is bigger than 8192 bytes long.
`offset += await Stream.ReadAsync(_buffer, offset, BufferSize - offset)` will at some point fill the buffer to 8192 and each subsequent call will read 0 bytes as the remaining buffer size `BufferSize - offset` is 0, because the read buffer never gets reset.


My pull request changes the behaviour so that the read buffer `_buffer` is always filled from offset 0, and written into the memorystream from offset 0. This effectively resets the buffer for each read.
The `if (_ms.Length > 32768)` also was never reached before, as the buffer wasn't reset after 8192. It should now be, but I haven't tested that.
You could consider returning a `413 Request Entity Too Large` that case.