### PR TITLE
Add overloads to .With*() module extension methods

### DIFF
--- a/src/EmbedIO/WebModuleContainerExtensions-Files.cs
+++ b/src/EmbedIO/WebModuleContainerExtensions-Files.cs
@@ -70,9 +70,7 @@ namespace EmbedIO
             where TContainer : class, IWebModuleContainer
         {
             var module = new FileModule(baseUrlPath, new FileSystemProvider(fileSystemPath, isImmutable));
-            configure?.Invoke(module);
-            @this.Modules.Add(name, module);
-            return @this;
+            return WithModule(@this, name, module, configure);
         }
 
         /// <summary>
@@ -132,9 +130,7 @@ namespace EmbedIO
             where TContainer : class, IWebModuleContainer
         {
             var module = new FileModule(baseUrlPath, new ResourceFileProvider(assembly, pathPrefix));
-            configure?.Invoke(module);
-            @this.Modules.Add(name, module);
-            return @this;
+            return WithModule(@this, name, module, configure);
         }
         
         /// <summary>
@@ -186,9 +182,7 @@ namespace EmbedIO
             where TContainer : class, IWebModuleContainer
         {
             var module = new FileModule(baseUrlPath, new ZipFileProvider(zipFilePath));
-            configure?.Invoke(module);
-            @this.Modules.Add(name, module);
-            return @this;
+            return WithModule(@this, name, module, configure);
         }
 
         /// <summary>
@@ -240,9 +234,7 @@ namespace EmbedIO
             where TContainer : class, IWebModuleContainer
         {
             var module = new FileModule(baseUrlPath, new ZipFileProvider(zipFileStream));
-            configure?.Invoke(module);
-            @this.Modules.Add(name, module);
-            return @this;
+            return WithModule(@this, name, module, configure);
         }
     }
 }

--- a/src/EmbedIO/WebModuleContainerExtensions-Files.cs
+++ b/src/EmbedIO/WebModuleContainerExtensions-Files.cs
@@ -44,6 +44,43 @@ namespace EmbedIO
         }
 
         /// <summary>
+        /// Creates an instance of <see cref="FileSystemProvider"/>, uses it to initialize
+        /// a <seealso cref="FileModule"/>, and adds the latter to a module container,
+        /// giving it the specified <paramref name="name"/> if not <see langword="null"/>.
+        /// </summary>
+        /// <typeparam name="TContainer">The type of the module container.</typeparam>
+        /// <param name="this">The <typeparamref name="TContainer"/> on which this method is called.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="baseUrlPath">The base URL path of the module.</param>
+        /// <param name="fileSystemPath">The path of the directory to serve.</param>
+        /// <param name="isImmutable"><see langword="true"/> if files and directories in
+        /// <paramref name="fileSystemPath"/> are not expected to change during a web server's
+        /// lifetime; <see langword="false"/> otherwise.</param>
+        /// <param name="configure">A callback used to configure the module.</param>
+        /// <returns><paramref name="this"/> with a <see cref="FileModule"/> added.</returns>
+        /// <exception cref="NullReferenceException"><paramref name="this"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="fileSystemPath"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="fileSystemPath"/> is not a valid local path.</exception>
+        /// <seealso cref="FileModule"/>
+        /// <seealso cref="FileSystemProvider"/>
+        /// <seealso cref="IWebModuleContainer.Modules"/>
+        /// <seealso cref="IComponentCollection{T}.Add"/>
+        public static TContainer WithStaticFolder<TContainer>(
+            this TContainer @this,
+            string name,
+            string baseUrlPath,
+            string fileSystemPath,
+            bool isImmutable,
+            Action<FileModule> configure = null)
+            where TContainer : class, IWebModuleContainer
+        {
+            var module = new FileModule(baseUrlPath, new FileSystemProvider(fileSystemPath, isImmutable));
+            configure?.Invoke(module);
+            @this.Modules.Add(name, module);
+            return @this;
+        }
+
+        /// <summary>
         /// Creates an instance of <see cref="ResourceFileProvider"/>, uses it to initialize
         /// a <seealso cref="FileModule"/>, and adds the latter to a module container.
         /// </summary>
@@ -72,6 +109,41 @@ namespace EmbedIO
             var module = new FileModule(baseUrlPath, new ResourceFileProvider(assembly, pathPrefix));
             configure?.Invoke(module);
             @this.Modules.Add(module);
+            return @this;
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="ResourceFileProvider"/>, uses it to initialize
+        /// a <seealso cref="FileModule"/>, and adds the latter to a module container,
+        /// giving it the specified <paramref name="name"/> if not <see langword="null"/>.
+        /// </summary>
+        /// <typeparam name="TContainer">The type of the module container.</typeparam>
+        /// <param name="this">The <typeparamref name="TContainer"/> on which this method is called.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="baseUrlPath">The base URL path of the module.</param>
+        /// <param name="assembly">The assembly where served files are contained as embedded resources.</param>
+        /// <param name="pathPrefix">A string to prepend to provider-specific paths
+        /// to form the name of a manifest resource in <paramref name="assembly"/>.</param>
+        /// <param name="configure">A callback used to configure the module.</param>
+        /// <returns><paramref name="this"/> with a <see cref="FileModule"/> added.</returns>
+        /// <exception cref="NullReferenceException"><paramref name="this"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="assembly"/> is <see langword="null"/>.</exception>
+        /// <seealso cref="FileModule"/>
+        /// <seealso cref="ResourceFileProvider"/>
+        /// <seealso cref="IWebModuleContainer.Modules"/>
+        /// <seealso cref="IComponentCollection{T}.Add"/>
+        public static TContainer WithEmbeddedResources<TContainer>(
+            this TContainer @this,
+            string name,
+            string baseUrlPath,
+            Assembly assembly,
+            string pathPrefix,
+            Action<FileModule> configure = null)
+            where TContainer : class, IWebModuleContainer
+        {
+            var module = new FileModule(baseUrlPath, new ResourceFileProvider(assembly, pathPrefix));
+            configure?.Invoke(module);
+            @this.Modules.Add(name, module);
             return @this;
         }
         
@@ -104,6 +176,37 @@ namespace EmbedIO
         }
 
         /// <summary>
+        /// Creates an instance of <see cref="ZipFileProvider"/> using a file-system path, uses it to initialize
+        /// a <seealso cref="FileModule"/>, and adds the latter to a module container,
+        /// giving it the specified <paramref name="name"/> if not <see langword="null"/>.
+        /// </summary>
+        /// <typeparam name="TContainer">The type of the module container.</typeparam>
+        /// <param name="this">The <typeparamref name="TContainer"/> on which this method is called.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="baseUrlPath">The base URL path of the module.</param>
+        /// <param name="zipFilePath">The zip file-system path.</param>
+        /// <param name="configure">A callback used to configure the module.</param>
+        /// <returns><paramref name="this"/> with a <see cref="FileModule"/> added.</returns>
+        /// <exception cref="NullReferenceException"><paramref name="this"/> is <see langword="null"/>.</exception>
+        /// <seealso cref="FileModule"/>
+        /// <seealso cref="ZipFileProvider"/>
+        /// <seealso cref="IWebModuleContainer.Modules"/>
+        /// <seealso cref="IComponentCollection{T}.Add"/>
+        public static TContainer WithZipFile<TContainer>(
+            this TContainer @this,
+            string name,
+            string baseUrlPath,
+            string zipFilePath,
+            Action<FileModule> configure = null)
+            where TContainer : class, IWebModuleContainer
+        {
+            var module = new FileModule(baseUrlPath, new ZipFileProvider(zipFilePath));
+            configure?.Invoke(module);
+            @this.Modules.Add(name, module);
+            return @this;
+        }
+
+        /// <summary>
         /// Creates an instance of <see cref="ZipFileProvider"/> using a zip file as stream, uses it to initialize
         /// a <seealso cref="FileModule"/>, and adds the latter to a module container.
         /// </summary>
@@ -128,6 +231,37 @@ namespace EmbedIO
             var module = new FileModule(baseUrlPath, new ZipFileProvider(zipFileStream));
             configure?.Invoke(module);
             @this.Modules.Add(module);
+            return @this;
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="ZipFileProvider"/> using a zip file as stream, uses it to initialize
+        /// a <seealso cref="FileModule"/>, and adds the latter to a module container,
+        /// giving it the specified <paramref name="name"/> if not <see langword="null"/>.
+        /// </summary>
+        /// <typeparam name="TContainer">The type of the module container.</typeparam>
+        /// <param name="this">The <typeparamref name="TContainer"/> on which this method is called.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="baseUrlPath">The base URL path of the module.</param>
+        /// <param name="zipFileStream">The zip file as stream.</param>
+        /// <param name="configure">A callback used to configure the module.</param>
+        /// <returns><paramref name="this"/> with a <see cref="FileModule"/> added.</returns>
+        /// <exception cref="NullReferenceException"><paramref name="this"/> is <see langword="null"/>.</exception>
+        /// <seealso cref="FileModule"/>
+        /// <seealso cref="ZipFileProvider"/>
+        /// <seealso cref="IWebModuleContainer.Modules"/>
+        /// <seealso cref="IComponentCollection{T}.Add"/>
+        public static TContainer WithZipFileStream<TContainer>(
+            this TContainer @this,
+            string name,
+            string baseUrlPath,
+            Stream zipFileStream,
+            Action<FileModule> configure = null)
+            where TContainer : class, IWebModuleContainer
+        {
+            var module = new FileModule(baseUrlPath, new ZipFileProvider(zipFileStream));
+            configure?.Invoke(module);
+            @this.Modules.Add(name, module);
             return @this;
         }
     }

--- a/src/EmbedIO/WebModuleContainerExtensions-Files.cs
+++ b/src/EmbedIO/WebModuleContainerExtensions-Files.cs
@@ -36,12 +36,7 @@ namespace EmbedIO
             bool isImmutable,
             Action<FileModule> configure = null)
             where TContainer : class, IWebModuleContainer
-        {
-            var module = new FileModule(baseUrlPath, new FileSystemProvider(fileSystemPath, isImmutable));
-            configure?.Invoke(module);
-            @this.Modules.Add(module);
-            return @this;
-        }
+            => WithStaticFolder(@this, null, baseUrlPath, fileSystemPath, isImmutable, configure);
 
         /// <summary>
         /// Creates an instance of <see cref="FileSystemProvider"/>, uses it to initialize
@@ -105,12 +100,7 @@ namespace EmbedIO
             string pathPrefix,
             Action<FileModule> configure = null)
             where TContainer : class, IWebModuleContainer
-        {
-            var module = new FileModule(baseUrlPath, new ResourceFileProvider(assembly, pathPrefix));
-            configure?.Invoke(module);
-            @this.Modules.Add(module);
-            return @this;
-        }
+            => WithEmbeddedResources(@this, null, baseUrlPath, assembly, pathPrefix, configure);
 
         /// <summary>
         /// Creates an instance of <see cref="ResourceFileProvider"/>, uses it to initialize
@@ -168,12 +158,7 @@ namespace EmbedIO
             string zipFilePath,
             Action<FileModule> configure = null)
             where TContainer : class, IWebModuleContainer
-        {
-            var module = new FileModule(baseUrlPath, new ZipFileProvider(zipFilePath));
-            configure?.Invoke(module);
-            @this.Modules.Add(module);
-            return @this;
-        }
+            => WithZipFile(@this, null, baseUrlPath, zipFilePath, configure);
 
         /// <summary>
         /// Creates an instance of <see cref="ZipFileProvider"/> using a file-system path, uses it to initialize
@@ -227,12 +212,7 @@ namespace EmbedIO
             Stream zipFileStream,
             Action<FileModule> configure = null)
             where TContainer : class, IWebModuleContainer
-        {
-            var module = new FileModule(baseUrlPath, new ZipFileProvider(zipFileStream));
-            configure?.Invoke(module);
-            @this.Modules.Add(module);
-            return @this;
-        }
+            => WithZipFileStream(@this, null, baseUrlPath, zipFileStream, configure);
 
         /// <summary>
         /// Creates an instance of <see cref="ZipFileProvider"/> using a zip file as stream, uses it to initialize

--- a/src/EmbedIO/WebModuleContainerExtensions-Routing.cs
+++ b/src/EmbedIO/WebModuleContainerExtensions-Routing.cs
@@ -33,5 +33,33 @@ namespace EmbedIO
 
             return @this;
         }
+
+        /// <summary>
+        /// Creates an instance of <see cref="RoutingModule"/> and adds it to a module container,
+        /// giving it the specified <paramref name="name"/> if not <see langword="null"/>.
+        /// </summary>
+        /// <typeparam name="TContainer">The type of the module container.</typeparam>
+        /// <param name="this">The <typeparamref name="TContainer"/> on which this method is called.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="baseUrlPath">The base URL path of the module.</param>
+        /// <param name="configure">A callback used to configure the newly-created <see cref="RoutingModule"/>.</param>
+        /// <returns><paramref name="this"/> with a <see cref="RoutingModule"/> added.</returns>
+        /// <exception cref="NullReferenceException"><paramref name="this"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="configure"/> is <see langword="null"/>.</exception>
+        /// <seealso cref="RoutingModule"/>
+        /// <seealso cref="RoutingModuleExtensions"/>
+        /// <seealso cref="IWebModuleContainer.Modules"/>
+        /// <seealso cref="IComponentCollection{T}.Add"/>
+        public static TContainer WithRouting<TContainer>(this TContainer @this, string name, string baseUrlPath, Action<RoutingModule> configure)
+            where TContainer : class, IWebModuleContainer
+        {
+            configure = Validate.NotNull(nameof(configure), configure);
+
+            var module = new RoutingModule(baseUrlPath);
+            configure(module);
+            @this.Modules.Add(name, module);
+
+            return @this;
+        }
     }
 }

--- a/src/EmbedIO/WebModuleContainerExtensions-Routing.cs
+++ b/src/EmbedIO/WebModuleContainerExtensions-Routing.cs
@@ -46,12 +46,8 @@ namespace EmbedIO
             where TContainer : class, IWebModuleContainer
         {
             configure = Validate.NotNull(nameof(configure), configure);
-
             var module = new RoutingModule(baseUrlPath);
-            configure(module);
-            @this.Modules.Add(name, module);
-
-            return @this;
+            return WithModule(@this, name, module, configure);
         }
     }
 }

--- a/src/EmbedIO/WebModuleContainerExtensions-Routing.cs
+++ b/src/EmbedIO/WebModuleContainerExtensions-Routing.cs
@@ -24,15 +24,7 @@ namespace EmbedIO
         /// <seealso cref="IComponentCollection{T}.Add"/>
         public static TContainer WithRouting<TContainer>(this TContainer @this, string baseUrlPath, Action<RoutingModule> configure)
             where TContainer : class, IWebModuleContainer
-        {
-            configure = Validate.NotNull(nameof(configure), configure);
-
-            var module = new RoutingModule(baseUrlPath);
-            configure(module);
-            @this.Modules.Add(module);
-
-            return @this;
-        }
+            => WithRouting(@this, null, baseUrlPath, configure);
 
         /// <summary>
         /// Creates an instance of <see cref="RoutingModule"/> and adds it to a module container,

--- a/src/EmbedIO/WebModuleContainerExtensions-WebApi.cs
+++ b/src/EmbedIO/WebModuleContainerExtensions-WebApi.cs
@@ -12,7 +12,7 @@ namespace EmbedIO
     {
         /// <summary>
         /// Creates an instance of <see cref="WebApiModule"/> using the default response serializer
-        /// and adds it to a module container.
+        /// and adds it to a module container without giving it a name.
         /// </summary>
         /// <typeparam name="TContainer">The type of the module container.</typeparam>
         /// <param name="this">The <typeparamref name="TContainer"/> on which this method is called.</param>
@@ -39,7 +39,7 @@ namespace EmbedIO
 
         /// <summary>
         /// Creates an instance of <see cref="WebApiModule"/> using the specified response serializer
-        /// and adds it to a module container.
+        /// and adds it to a module container without giving it a name.
         /// </summary>
         /// <typeparam name="TContainer">The type of the module container.</typeparam>
         /// <param name="this">The <typeparamref name="TContainer"/> on which this method is called.</param>
@@ -71,6 +71,80 @@ namespace EmbedIO
             var module = new WebApiModule(baseUrlPath, serializer);
             configure(module);
             @this.Modules.Add(module);
+
+            return @this;
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="WebApiModule"/> using the default response serializer
+        /// and adds it to a module container, giving it the specified <paramref name="name"/>
+        /// if not <see langword="null"/>
+        /// </summary>
+        /// <typeparam name="TContainer">The type of the module container.</typeparam>
+        /// <param name="this">The <typeparamref name="TContainer"/> on which this method is called.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="baseUrlPath">The base URL path of the module.</param>
+        /// <param name="configure">A callback used to configure the newly-created <see cref="WebApiModule"/>.</param>
+        /// <returns><paramref name="this"/> with a <see cref="RoutingModule"/> added.</returns>
+        /// <exception cref="NullReferenceException"><paramref name="this"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="configure"/> is <see langword="null"/>.</exception>
+        /// <seealso cref="WebApiModule"/>
+        /// <seealso cref="WebApiModuleExtensions"/>
+        /// <seealso cref="IWebModuleContainer.Modules"/>
+        /// <seealso cref="IComponentCollection{T}.Add"/>
+        public static TContainer WithWebApi<TContainer>(
+            this TContainer @this,
+            string name,
+            string baseUrlPath,
+            Action<WebApiModule> configure)
+            where TContainer : class, IWebModuleContainer
+        {
+            configure = Validate.NotNull(nameof(configure), configure);
+
+            var module = new WebApiModule(baseUrlPath);
+            configure(module);
+            @this.Modules.Add(name, module);
+
+            return @this;
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="WebApiModule"/>, using the specified response serializer
+        /// and adds it to a module container, giving it the specified <paramref name="name"/>
+        /// if not <see langword="null"/>
+        /// </summary>
+        /// <typeparam name="TContainer">The type of the module container.</typeparam>
+        /// <param name="this">The <typeparamref name="TContainer"/> on which this method is called.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="baseUrlPath">The base URL path of the module.</param>
+        /// <param name="serializer">A <see cref="ResponseSerializerCallback"/> used to serialize
+        /// the result of controller methods returning <see langword="object"/>
+        /// or <see cref="Task{TResult}">Task&lt;object&gt;</see>.</param>
+        /// <param name="configure">A callback used to configure the newly-created <see cref="WebApiModule"/>.</param>
+        /// <returns><paramref name="this"/> with a <see cref="RoutingModule"/> added.</returns>
+        /// <exception cref="NullReferenceException"><paramref name="this"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <para><paramref name="serializer"/> is <see langword="null"/>.</para>
+        /// <para>- or -</para>
+        /// <para><paramref name="configure"/> is <see langword="null"/>.</para>
+        /// </exception>
+        /// <seealso cref="WebApiModule"/>
+        /// <seealso cref="WebApiModuleExtensions"/>
+        /// <seealso cref="IWebModuleContainer.Modules"/>
+        /// <seealso cref="IComponentCollection{T}.Add"/>
+        public static TContainer WithWebApi<TContainer>(
+            this TContainer @this,
+            string name,
+            string baseUrlPath,
+            ResponseSerializerCallback serializer,
+            Action<WebApiModule> configure)
+            where TContainer : class, IWebModuleContainer
+        {
+            configure = Validate.NotNull(nameof(configure), configure);
+
+            var module = new WebApiModule(baseUrlPath, serializer);
+            configure(module);
+            @this.Modules.Add(name, module);
 
             return @this;
         }

--- a/src/EmbedIO/WebModuleContainerExtensions-WebApi.cs
+++ b/src/EmbedIO/WebModuleContainerExtensions-WebApi.cs
@@ -27,15 +27,7 @@ namespace EmbedIO
         /// <seealso cref="IComponentCollection{T}.Add"/>
         public static TContainer WithWebApi<TContainer>(this TContainer @this, string baseUrlPath, Action<WebApiModule> configure)
             where TContainer : class, IWebModuleContainer
-        {
-            configure = Validate.NotNull(nameof(configure), configure);
-
-            var module = new WebApiModule(baseUrlPath);
-            configure(module);
-            @this.Modules.Add(module);
-
-            return @this;
-        }
+            => WithWebApi(@this, null, baseUrlPath, configure);
 
         /// <summary>
         /// Creates an instance of <see cref="WebApiModule"/> using the specified response serializer
@@ -65,15 +57,7 @@ namespace EmbedIO
             ResponseSerializerCallback serializer,
             Action<WebApiModule> configure)
             where TContainer : class, IWebModuleContainer
-        {
-            configure = Validate.NotNull(nameof(configure), configure);
-
-            var module = new WebApiModule(baseUrlPath, serializer);
-            configure(module);
-            @this.Modules.Add(module);
-
-            return @this;
-        }
+            => WithWebApi(@this, null, baseUrlPath, serializer, configure);
 
         /// <summary>
         /// Creates an instance of <see cref="WebApiModule"/> using the default response serializer

--- a/src/EmbedIO/WebModuleContainerExtensions-WebApi.cs
+++ b/src/EmbedIO/WebModuleContainerExtensions-WebApi.cs
@@ -84,12 +84,8 @@ namespace EmbedIO
             where TContainer : class, IWebModuleContainer
         {
             configure = Validate.NotNull(nameof(configure), configure);
-
             var module = new WebApiModule(baseUrlPath);
-            configure(module);
-            @this.Modules.Add(name, module);
-
-            return @this;
+            return WithModule(@this, name, module, configure);
         }
 
         /// <summary>
@@ -125,12 +121,8 @@ namespace EmbedIO
             where TContainer : class, IWebModuleContainer
         {
             configure = Validate.NotNull(nameof(configure), configure);
-
             var module = new WebApiModule(baseUrlPath, serializer);
-            configure(module);
-            @this.Modules.Add(name, module);
-
-            return @this;
+            return WithModule(@this, name, module, configure);
         }
     }
 }

--- a/src/EmbedIO/WebModuleContainerExtensions.cs
+++ b/src/EmbedIO/WebModuleContainerExtensions.cs
@@ -40,5 +40,45 @@ namespace EmbedIO
             @this.Modules.Add(name, module);
             return @this;
         }
+
+        /// <summary>
+        /// Adds the specified <paramref name="module"/> to a module container, without giving it a name.
+        /// </summary>
+        /// <typeparam name="TContainer">The type of the module container.</typeparam>
+        /// <typeparam name="TWebModule">The type of the <paramref name="module"/>.</typeparam>
+        /// <param name="this">The <typeparamref name="TContainer"/> on which this method is called.</param>
+        /// <param name="module">The module.</param>
+        /// <param name="configure">A callback used to configure the <paramref name="module"/>.</param>
+        /// <returns><paramref name="this"/> with <paramref name="module"/> added.</returns>
+        /// <exception cref="NullReferenceException"><paramref name="this"/> is <see langword="null"/>.</exception>
+        /// <seealso cref="IWebModuleContainer.Modules"/>
+        /// <seealso cref="IComponentCollection{T}.Add"/>
+        public static TContainer WithModule<TContainer, TWebModule>(this TContainer @this, TWebModule module, Action<TWebModule> configure)
+            where TContainer : class, IWebModuleContainer
+            where TWebModule : IWebModule
+        => WithModule(@this, null, module, configure);
+
+        /// <summary>
+        /// Adds the specified <paramref name="module"/> to a module container,
+        /// giving it the specified <paramref name="name"/> if not <see langword="null"/>.
+        /// </summary>
+        /// <typeparam name="TContainer">The type of the module container.</typeparam>
+        /// <typeparam name="TWebModule">The type of the <paramref name="module"/>.</typeparam>
+        /// <param name="this">The <typeparamref name="TContainer"/> on which this method is called.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="module">The module.</param>
+        /// <param name="configure">A callback used to configure the <paramref name="module"/>.</param>
+        /// <returns><paramref name="this"/> with <paramref name="module"/> added.</returns>
+        /// <exception cref="NullReferenceException"><paramref name="this"/> is <see langword="null"/>.</exception>
+        /// <seealso cref="IWebModuleContainer.Modules"/>
+        /// <seealso cref="IComponentCollection{T}.Add"/>
+        public static TContainer WithModule<TContainer, TWebModule>(this TContainer @this, string name, TWebModule module, Action<TWebModule> configure)
+            where TContainer : class, IWebModuleContainer
+            where TWebModule : IWebModule
+        {
+            configure?.Invoke(module);
+            @this.Modules.Add(name, module);
+            return @this;
+        }
     }
 }

--- a/src/EmbedIO/WebServerExtensions-SessionManager.cs
+++ b/src/EmbedIO/WebServerExtensions-SessionManager.cs
@@ -27,13 +27,16 @@ namespace EmbedIO
         /// </summary>
         /// <typeparam name="TWebServer">The type of the web server.</typeparam>
         /// <param name="this">The <see cref="IWebServer"/> on which this method is called.</param>
+        /// <param name="configure">A callback used to configure the session manager.</param>
         /// <returns><paramref name="this"/> with the session manager set.</returns>
         /// <exception cref="NullReferenceException"><paramref name="this"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException">The web server has already been started.</exception>
-        public static TWebServer WithLocalSessionManager<TWebServer>(this TWebServer @this)
+        public static TWebServer WithLocalSessionManager<TWebServer>(this TWebServer @this, Action<LocalSessionManager> configure = null)
             where TWebServer : IWebServer
         {
-            @this.SessionManager = new LocalSessionManager();
+            var sessionManager = new LocalSessionManager();
+            configure?.Invoke(sessionManager);
+            @this.SessionManager = sessionManager;
             return @this;
         }
     }


### PR DESCRIPTION
Hi!
This PR overloads with a `name` parameter to most `IWebModuleContainer` `.With*()` extensions methods:
* Both `WithRouting()` methods
* Both `WithWebApi()` methods
* All `With*()` methods in `WebModuleContainerExtensions-Files.cs`

I did not add overloads to the `WithAction()` and `On[Verb]()` methods because I am not sure it would be useful and that's a lot of methods. I did not try either to add overloads to the `WithCors()` methods because of the potential ambiguity of a new string parameter in these methods with a lots of optional string parameters. I am also not sure either if it would be useful either.

This PR adds also a `configure` parameter to these methods:
* `WithLocalSessionManager()` via an optinal parameter
* `WithModule()` via new generic overloads

This PR comes from my need of `configure` parameter in `WithLocalSessionManager()` and a `name` parameter in `WithWebApi()`.
And so, why not be exhaustive?