### PR TITLE
Content Length issue #355

### DIFF
--- a/src/EmbedIO/HttpResponseExtensions.cs
+++ b/src/EmbedIO/HttpResponseExtensions.cs
@@ -38,7 +38,6 @@ namespace EmbedIO
             @this.StatusDescription = statusDescription;
             @this.ContentType = string.Empty;
             @this.ContentEncoding = null;
-            @this.ContentLength64 = 0;
         }
     }
 }

--- a/src/EmbedIO/HttpResponseExtensions.cs
+++ b/src/EmbedIO/HttpResponseExtensions.cs
@@ -38,6 +38,7 @@ namespace EmbedIO
             @this.StatusDescription = statusDescription;
             @this.ContentType = string.Empty;
             @this.ContentEncoding = null;
+            @this.ContentLength64 = 0;
         }
     }
 }

--- a/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
@@ -304,7 +304,7 @@ namespace EmbedIO.Net.Internal
 
             CreateQueryString(_url.Query);
             
-            if (ContentLength64 < 0 && (HttpVerb == HttpVerbs.Post || HttpVerb == HttpVerbs.Put))
+            if (ContentLength64 == 0 && (HttpVerb == HttpVerbs.Post || HttpVerb == HttpVerbs.Put))
                 return;
 
             if (string.Compare(Headers["Expect"], "100-continue", StringComparison.OrdinalIgnoreCase) == 0)

--- a/src/EmbedIO/Net/Internal/HttpListenerResponse.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerResponse.cs
@@ -17,8 +17,6 @@ namespace EmbedIO.Net.Internal
         private const string CannotChangeHeaderWarning = "Cannot be changed after headers are sent.";
         private readonly HttpListenerContext _context;
         private bool _disposed;
-        private long _contentLength;
-        private bool _clSet;
         private string _contentType;
         private CookieList _cookies;
         private bool _keepAlive = true;
@@ -37,7 +35,7 @@ namespace EmbedIO.Net.Internal
         /// <inheritdoc />
         public long ContentLength64
         {
-            get => _contentLength;
+            get => Headers.ContainsKey(HttpHeaderNames.ContentLength) && long.TryParse(Headers[HttpHeaderNames.ContentLength], out var val) ? val : 0;
 
             set
             {
@@ -49,9 +47,8 @@ namespace EmbedIO.Net.Internal
 
                 if (value < 0)
                     throw new ArgumentOutOfRangeException(nameof(value), "Must be >= 0");
-
-                _clSet = true;
-                _contentLength = value;
+                
+                Headers[HttpHeaderNames.ContentLength] = value.ToString();
             }
         }
 
@@ -208,20 +205,18 @@ namespace EmbedIO.Net.Internal
             if (Headers[HttpHeaderNames.Date] == null)
                 Headers.Add(HttpHeaderNames.Date, DateTime.UtcNow.ToString("r", inv));
 
+            var clSet = ContentLength64 > 0;
+
             if (!_chunked)
             {
-                if (!_clSet && closing)
+                if (!clSet && closing)
                 {
-                    _clSet = true;
-                    _contentLength = 0;
+                    clSet = true;
                 }
-
-                if (_clSet)
-                    Headers.Add(HttpHeaderNames.ContentLength, _contentLength.ToString(inv));
             }
 
             var v = _context.Request.ProtocolVersion;
-            if (!_clSet && !_chunked && v >= HttpVersion.Version11)
+            if (!clSet && !_chunked && v >= HttpVersion.Version11)
                 _chunked = true;
 
             //// Apache forces closing the connection for these status codes:

--- a/src/EmbedIO/Net/Internal/HttpListenerResponse.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerResponse.cs
@@ -212,6 +212,9 @@ namespace EmbedIO.Net.Internal
                 if (!clSet && closing)
                 {
                     clSet = true;
+
+                    if (!Headers.ContainsKey(HttpHeaderNames.ContentLength))
+                        Headers[HttpHeaderNames.ContentLength] = "0";
                 }
             }
 

--- a/test/EmbedIO.Tests/EndToEndFixtureBase.cs
+++ b/test/EmbedIO.Tests/EndToEndFixtureBase.cs
@@ -13,8 +13,6 @@ namespace EmbedIO.Tests
 
         protected EndToEndFixtureBase(bool useTestWebServer)
         {
-            // Terminal.Settings.GlobalLoggingMessageType = LogMessageType.None;
-
             _useTestWebServer = useTestWebServer;
         }
 

--- a/test/EmbedIO.Tests/Issues/Issue352_FileSystemProviderEscapedString.cs
+++ b/test/EmbedIO.Tests/Issues/Issue352_FileSystemProviderEscapedString.cs
@@ -1,0 +1,38 @@
+﻿using EmbedIO.Testing;
+using System.Net.Http;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace EmbedIO.Tests.Issues
+{
+    public class Issue352_FileSystemProviderEscapedString
+    {
+        [Test]
+        public Task FileSystemProvider_Handle_PathWithEscapedString()
+        {
+            const string ok = "Content";
+
+            var tempFolder = $"Folder {DateTime.Now.Ticks}";
+            var tempPathWithWhitespace = Path.Combine(Path.GetTempPath(), tempFolder);
+            Directory.CreateDirectory(tempPathWithWhitespace);
+            var tempFile = Path.Combine(tempPathWithWhitespace, "index.html");
+            File.WriteAllText(tempFile, ok);
+
+            void Configure(IWebServer server) => server
+                .WithStaticFolder("/", Path.GetTempPath(), true);
+
+            async Task Use(HttpClient client)
+            {
+                using (var response = await client.GetAsync($"/{tempFolder}").ConfigureAwait(false))
+                {
+                    var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    Assert.AreEqual(ok, responseString);
+                }
+            }
+
+            return TestWebServer.UseAsync(Configure, Use);
+        }
+    }
+}

--- a/test/EmbedIO.Tests/Issues/Issue355_ContentResponseLength.cs
+++ b/test/EmbedIO.Tests/Issues/Issue355_ContentResponseLength.cs
@@ -1,0 +1,36 @@
+﻿using EmbedIO.Testing;
+using NUnit.Framework;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EmbedIO.Tests.Issues
+{
+    public class Issue355_ContentResponseLength
+    {
+        [Test]
+        public Task ActionModule_Handle_ContentLengthProperly()
+        {
+            var ok = Encoding.UTF8.GetBytes("content");
+
+            void Configure(IWebServer server) => server
+                .WithAction("/", HttpVerbs.Get, async context =>
+                {
+                    context.Response.Headers[HttpHeaderNames.ContentLength] = ok.Length.ToString();
+                    await context.Response.OutputStream.WriteAsync(ok, 0, ok.Length);
+                });
+
+            async Task Use(HttpClient client)
+            {
+                using (var response = await client.GetAsync($"/").ConfigureAwait(false))
+                {
+                    var responseArray = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+
+                    Assert.AreEqual(ok[0], responseArray[0]);
+                }
+            }
+
+            return TestWebServer.UseAsync(Configure, Use);
+        }
+    }
+}

--- a/test/EmbedIO.Tests/Issues/Issue355_ContentResponseLength.cs
+++ b/test/EmbedIO.Tests/Issues/Issue355_ContentResponseLength.cs
@@ -7,8 +7,9 @@ namespace EmbedIO.Tests.Issues
 {
     public class Issue355_ContentResponseLength
     {
-        [Test]
-        public async Task ActionModule_Handle_ContentLengthProperly()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task ActionModule_Handle_ContentLengthProperly(bool useProperty)
         {
             var ok = Encoding.UTF8.GetBytes("content");
 
@@ -16,7 +17,11 @@ namespace EmbedIO.Tests.Issues
             {
                 server.WithAction("/", HttpVerbs.Get, async context =>
                 {
-                    context.Response.Headers[HttpHeaderNames.ContentLength] = ok.Length.ToString();
+                    if (useProperty)
+                        context.Response.ContentLength64 = ok.Length;
+                    else
+                        context.Response.Headers[HttpHeaderNames.ContentLength] = ok.Length.ToString();
+
                     await context.Response.OutputStream.WriteAsync(ok, 0, ok.Length);
                 });
 

--- a/test/EmbedIO.Tests/Issues/Issue355_ContentResponseLength.cs
+++ b/test/EmbedIO.Tests/Issues/Issue355_ContentResponseLength.cs
@@ -1,5 +1,4 @@
-﻿using EmbedIO.Testing;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -9,28 +8,30 @@ namespace EmbedIO.Tests.Issues
     public class Issue355_ContentResponseLength
     {
         [Test]
-        public Task ActionModule_Handle_ContentLengthProperly()
+        public async Task ActionModule_Handle_ContentLengthProperly()
         {
             var ok = Encoding.UTF8.GetBytes("content");
 
-            void Configure(IWebServer server) => server
-                .WithAction("/", HttpVerbs.Get, async context =>
+            using (var server = new WebServer(1234))
+            {
+                server.WithAction("/", HttpVerbs.Get, async context =>
                 {
                     context.Response.Headers[HttpHeaderNames.ContentLength] = ok.Length.ToString();
                     await context.Response.OutputStream.WriteAsync(ok, 0, ok.Length);
                 });
 
-            async Task Use(HttpClient client)
-            {
-                using (var response = await client.GetAsync($"/").ConfigureAwait(false))
-                {
-                    var responseArray = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                server.RunAsync();
 
-                    Assert.AreEqual(ok[0], responseArray[0]);
+                using (var client = new HttpClient())
+                {
+                    using (var response = await client.GetAsync("http://localhost:1234/").ConfigureAwait(false))
+                    {
+                        var responseArray = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+
+                        Assert.AreEqual(ok[0], responseArray[0]);
+                    }
                 }
             }
-
-            return TestWebServer.UseAsync(Configure, Use);
         }
     }
 }


### PR DESCRIPTION
I changed how the Content-Length is used in Request and Response. Instead of use a private member, they use the same value in Headers collection.