### PR TITLE
Use only headers mentioned in RFC6455 in WebSocket opening handshake.

### DIFF
--- a/src/EmbedIO/Net/Internal/WebSocketHandshakeResponse.cs
+++ b/src/EmbedIO/Net/Internal/WebSocketHandshakeResponse.cs
@@ -14,6 +14,7 @@ namespace EmbedIO.Net.Internal
         {
             ProtocolVersion = HttpVersion.Version11;
             Headers = context.Response.Headers;
+            Headers.Clear(); // Use only headers mentioned in RFC6455 - scrap all the rest.
             StatusCode = HandshakeStatusCode;
             Reason = HttpListenerResponseHelper.GetStatusDescription(HandshakeStatusCode);
 


### PR DESCRIPTION
This should return WebSockets back to the point they were before I attempted to fix #358.