### PR TITLE
add new HttpException.InternalServerError shortcut

### DIFF
--- a/src/EmbedIO/HttpException-Shortcuts.cs
+++ b/src/EmbedIO/HttpException-Shortcuts.cs
@@ -7,7 +7,7 @@ namespace EmbedIO
     {
         /// <summary>
         /// Returns a new instance of <see cref="HttpException" /> that, when thrown,
-        /// will break the request handling control flow and send a <c>500 InternalServerError</c>
+        /// will break the request handling control flow and send a <c>500 Internal Server Error</c>
         /// response to the client.
         /// </summary>
         /// <param name="message">A message to include in the response.</param>

--- a/src/EmbedIO/HttpException-Shortcuts.cs
+++ b/src/EmbedIO/HttpException-Shortcuts.cs
@@ -7,6 +7,19 @@ namespace EmbedIO
     {
         /// <summary>
         /// Returns a new instance of <see cref="HttpException" /> that, when thrown,
+        /// will break the request handling control flow and send a <c>500 InternalServerError</c>
+        /// response to the client.
+        /// </summary>
+        /// <param name="message">A message to include in the response.</param>
+        /// <param name="data">The data object to include in the response.</param>
+        /// <returns>
+        /// A newly-created <see cref="HttpException" />.
+        /// </returns>
+        public static HttpException InternalServerError(string message = null, object data = null)
+            => new HttpException(HttpStatusCode.InternalServerError, message, data);
+        
+        /// <summary>
+        /// Returns a new instance of <see cref="HttpException" /> that, when thrown,
         /// will break the request handling control flow and send a <c>401 Unauthorized</c>
         /// response to the client.
         /// </summary>


### PR DESCRIPTION
The 500 error code is used for server error. 
Useful when an exception is caught inside a WebApiController and then thrown as a 500 error.