### PR TITLE
[FIX] ModuleGroup does not implement IDisposable...

### DIFF
--- a/src/EmbedIO/Files/ZipFileProvider.cs
+++ b/src/EmbedIO/Files/ZipFileProvider.cs
@@ -87,8 +87,8 @@ namespace EmbedIO.Files
         }
 
         /// <inheritdoc />
-        public Stream? OpenFile(string path)
-            => _zipArchive.GetEntry(path)?.Open();
+        public Stream OpenFile(string path)
+            => _zipArchive.GetEntry(path)?.Open() ?? throw new FileNotFoundException($"\"{path}\" cannot be found in Zip archive.");
 
         /// <inheritdoc />
         public IEnumerable<MappedResourceInfo> GetDirectoryEntries(string path, IMimeTypeProvider mimeTypeProvider)

--- a/src/EmbedIO/ModuleGroup.cs
+++ b/src/EmbedIO/ModuleGroup.cs
@@ -21,7 +21,7 @@ namespace EmbedIO
     /// <seealso cref="WebModuleBase" />
     /// <seealso cref="IDisposable" />
     /// <seealso cref="IWebModuleContainer" />
-    public class ModuleGroup : WebModuleBase, IWebModuleContainer, IMimeTypeCustomizer
+    public class ModuleGroup : WebModuleBase, IDisposable, IWebModuleContainer, IMimeTypeCustomizer
     {
         private readonly WebModuleCollection _modules;
         private readonly MimeTypeCustomizer _mimeTypeCustomizer = new MimeTypeCustomizer();


### PR DESCRIPTION
…despite having a `Dispose` method.

This is a leftover of the removal of IDisposable from `IWebModuleCollection`.