### PR TITLE
Fix #465 (QueryFieldAttribute not respecting parameter default)

### DIFF
--- a/src/packages/EmbedIO/WebApi/FormFieldAttribute.cs
+++ b/src/packages/EmbedIO/WebApi/FormFieldAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using EmbedIO.Utilities;
@@ -149,10 +149,11 @@ namespace EmbedIO.WebApi
             if (!data.ContainsKey(fieldName) && BadRequestIfMissing)
                 throw HttpException.BadRequest($"Missing form field {fieldName}.");
 
+            object result = null;
             if (type.IsArray)
             {
                 var fieldValues = data.GetValues(fieldName) ?? Array.Empty<string>();
-                if (!FromString.TryConvertTo(type, fieldValues, out var result))
+                if (!FromString.TryConvertTo(type, fieldValues, out result))
                     throw HttpException.BadRequest($"Cannot convert field {fieldName} to an array of {type.GetElementType().Name}.");
 
                 return result;
@@ -161,9 +162,17 @@ namespace EmbedIO.WebApi
             {
                 var fieldValue = data.GetValues(fieldName)?.LastOrDefault();
                 if (fieldValue == null)
-                    return type.IsValueType ? Activator.CreateInstance(type) : null;
+                {
+                    if (type.IsValueType)
+                    {
+                        var parameter = controller.CurrentMethod.GetParameters().FirstOrDefault(p => p.Name == parameterName);
+                        result = parameter.HasDefaultValue ? parameter.DefaultValue : Activator.CreateInstance(type);
+                    }
 
-                if (!FromString.TryConvertTo(type, fieldValue, out var result))
+                    return Task.FromResult(result);
+                }
+
+                if (!FromString.TryConvertTo(type, fieldValue, out result))
                     throw HttpException.BadRequest($"Cannot convert field {fieldName} to {type.Name}.");
 
                 return result;

--- a/src/packages/EmbedIO/WebApi/WebApiController.cs
+++ b/src/packages/EmbedIO/WebApi/WebApiController.cs
@@ -1,4 +1,6 @@
-﻿using System.Security.Principal;
+using System.Linq;
+using System.Reflection;
+using System.Security.Principal;
 using System.Threading;
 using EmbedIO.Routing;
 using EmbedIO.Sessions;
@@ -54,6 +56,13 @@ namespace EmbedIO.WebApi
         /// Gets the session proxy associated with the HTTP context.
         /// </summary>
         public ISessionProxy Session => HttpContext.Session;
+
+        /// <summary>
+        /// Gets the method of the controller that will be called by the current route.
+        /// </summary>
+        internal MethodInfo CurrentMethod => GetType().GetMethods()
+            .FirstOrDefault(m => m.GetCustomAttributes<RouteAttribute>(true)
+                .Any(ca => ca.Verb == HttpContext.Request.HttpVerb && ca.Matcher.Match(HttpContext.Route.SubPath) != null));
 
         /// <summary>
         /// <para>This method is meant to be called internally by EmbedIO.</para>


### PR DESCRIPTION
This work makes it so that `QueryFieldAttribute` respects the default value set for a parameter when instantiating it, in case the parameter is not present in the query string of the request.
I also took the chance and applied the same fix to `FormFieldAttribute` since the logic of them is very similar.