### PR TITLE
Unspecified request encoding should default to UTF-8.

### DIFF
--- a/src/EmbedIO/Net/Internal/HeaderUtility.cs
+++ b/src/EmbedIO/Net/Internal/HeaderUtility.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Linq;
+
+namespace EmbedIO.Net.Internal
+{
+    internal static class HeaderUtility
+    {
+        public static string? GetCharset(string? contentType)
+            => contentType?
+                .Split(';')
+                .Select(p => p.Trim())
+                .Where(part => part.StartsWith("charset", StringComparison.OrdinalIgnoreCase))
+                .Select(GetAttributeValue)
+                .FirstOrDefault();
+
+        public static string? GetAttributeValue(string nameAndValue)
+        {
+            var idx = nameAndValue.IndexOf('=');
+
+            return idx < 0 || idx == nameAndValue.Length - 1 ? null : nameAndValue.Substring(idx + 1).Trim().Unquote();
+        }
+    }
+}

--- a/src/EmbedIO/Net/Internal/SystemHttpRequest.cs
+++ b/src/EmbedIO/Net/Internal/SystemHttpRequest.cs
@@ -62,7 +62,31 @@ namespace EmbedIO.Net.Internal
         public Stream InputStream => _request.InputStream;
 
         /// <inheritdoc />
-        public Encoding ContentEncoding => _request.ContentEncoding;
+        public Encoding ContentEncoding
+        {
+            get
+            {
+                if (_request.HasEntityBody && _request.ContentType != null)
+                {
+                    var charSet = HeaderUtility.GetCharset(ContentType);
+                    if (charSet != null)
+                    {
+                        try
+                        {
+                            return Encoding.GetEncoding(charSet);
+                        }
+                        catch (ArgumentException)
+                        {
+                        }
+                    }
+                }
+
+                // Microsoft's implementation returns Encoding.Default,
+                // which is the system's active code page in .NET Framework.
+                // Return UTF-8 instead, like .NET Core's HttpListenerRequest.
+                return Encoding.UTF8;
+            }
+        }
 
         /// <inheritdoc />
         public IPEndPoint RemoteEndPoint { get; }


### PR DESCRIPTION
Partial fix for #472, also harmonizes ContentEncoding between listener modes,
