### PR TITLE
[ADD] WebServer.DefaultEncoding static readonly field.

### DIFF
--- a/src/EmbedIO.Testing/Internal/TestRequest.cs
+++ b/src/EmbedIO.Testing/Internal/TestRequest.cs
@@ -53,7 +53,7 @@ namespace EmbedIO.Testing.Internal
             HttpVerb = HttpMethodToVerb(clientRequest.Method);
             Url = clientRequest.RequestUri;
             HasEntityBody = _content != null;
-            ContentEncoding = Encoding.GetEncoding(_content?.Headers.ContentType?.CharSet ?? Encoding.UTF8.WebName);
+            ContentEncoding = Encoding.GetEncoding(_content?.Headers.ContentType?.CharSet ?? WebServer.DefaultEncoding.WebName);
             RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 9999);
             UserAgent = clientRequest.Headers.UserAgent?.ToString();
             LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 8080);

--- a/src/EmbedIO.Testing/Internal/TestResponse.cs
+++ b/src/EmbedIO.Testing/Internal/TestResponse.cs
@@ -24,7 +24,7 @@ namespace EmbedIO.Testing.Internal
 
         public ICookieCollection Cookies { get; } = new Net.CookieList();
 
-        public Encoding? ContentEncoding { get; set; } = Encoding.UTF8;
+        public Encoding? ContentEncoding { get; set; } = WebServer.DefaultEncoding;
 
         public bool KeepAlive { get; set; }
 

--- a/src/EmbedIO.Testing/MockFileProvider.MockFile.cs
+++ b/src/EmbedIO.Testing/MockFileProvider.MockFile.cs
@@ -16,7 +16,7 @@ namespace EmbedIO.Testing
             {
                 Data = text == null
                     ? Array.Empty<byte>()
-                    : Encoding.UTF8.GetBytes(text);
+                    : WebServer.DefaultEncoding.GetBytes(text);
             }
 
             public byte[] Data { get; private set; }
@@ -31,7 +31,7 @@ namespace EmbedIO.Testing
             {
                 Data = text == null
                     ? Array.Empty<byte>()
-                    : Encoding.UTF8.GetBytes(text);
+                    : WebServer.DefaultEncoding.GetBytes(text);
                 Touch();
             }
         }

--- a/src/EmbedIO.Testing/StockResource.cs
+++ b/src/EmbedIO.Testing/StockResource.cs
@@ -165,7 +165,7 @@ namespace EmbedIO.Testing
         public static string GetText(string path, Encoding? encoding = null)
         {
             using var stream = Open(path);
-            using var reader = new StreamReader(stream, encoding ?? Encoding.UTF8, false, WebServer.StreamCopyBufferSize, true);
+            using var reader = new StreamReader(stream, encoding ?? WebServer.DefaultEncoding, false, WebServer.StreamCopyBufferSize, true);
             return reader.ReadToEnd();
         }
 

--- a/src/EmbedIO/Authentication/BasicAuthenticationModuleBase.cs
+++ b/src/EmbedIO/Authentication/BasicAuthenticationModuleBase.cs
@@ -87,7 +87,7 @@ namespace EmbedIO.Authentication
             string credentials;
             try
             {
-                credentials = Encoding.UTF8.GetString(Convert.FromBase64String(authHeader.Substring(6).Trim()));
+                credentials = WebServer.DefaultEncoding.GetString(Convert.FromBase64String(authHeader.Substring(6).Trim()));
             }
             catch (FormatException)
             {

--- a/src/EmbedIO/Files/Internal/HtmlDirectoryLister.cs
+++ b/src/EmbedIO/Files/Internal/HtmlDirectoryLister.cs
@@ -22,7 +22,7 @@ namespace EmbedIO.Files.Internal
 
         public static IDirectoryLister Instance => LazyInstance.Value;
 
-        public string ContentType { get; } = MimeType.Html + "; encoding=" + Encoding.UTF8.WebName;
+        public string ContentType { get; } = MimeType.Html + "; encoding=" + WebServer.DefaultEncoding.WebName;
 
         public async Task ListDirectoryAsync(
             MappedResourceInfo info,
@@ -38,7 +38,7 @@ namespace EmbedIO.Files.Internal
                 throw SelfCheck.Failure($"{nameof(HtmlDirectoryLister)}.{nameof(ListDirectoryAsync)} invoked with a file, not a directory.");
 
             var encodedPath = WebUtility.HtmlEncode(absoluteUrlPath);
-            using var text = new StreamWriter(stream, Encoding.UTF8);
+            using var text = new StreamWriter(stream, WebServer.DefaultEncoding);
             text.Write("<html><head><title>Index of ");
             text.Write(encodedPath);
             text.Write("</title></head><body><h1>Index of ");

--- a/src/EmbedIO/HttpContextExtensions-RequestStream.cs
+++ b/src/EmbedIO/HttpContextExtensions-RequestStream.cs
@@ -47,8 +47,6 @@ namespace EmbedIO
         /// <summary>
         /// <para>Wraps the request input stream and returns a <see cref="TextReader" /> that can be used directly.</para>
         /// <para>Decompression of compressed request bodies is implemented if specified in the web server's options.</para>
-        /// <para>If the request does not specify a content encoding,
-        /// <see cref="Encoding.UTF8">UTF-8</see> is used by default.</para>
         /// </summary>
         /// <param name="this">The <see cref="IHttpContext" /> on which this method is called.</param>
         /// <returns>
@@ -58,6 +56,6 @@ namespace EmbedIO
         /// <seealso cref="OpenRequestStream"/>
         /// <seealso cref="WebServerOptionsBase.SupportCompressedRequests"/>
         public static TextReader OpenRequestText(this IHttpContext @this)
-            => new StreamReader(OpenRequestStream(@this), @this.Request.ContentEncoding ?? Encoding.UTF8);
+            => new StreamReader(OpenRequestStream(@this), @this.Request.ContentEncoding);
     }
 }

--- a/src/EmbedIO/HttpContextExtensions-ResponseStream.cs
+++ b/src/EmbedIO/HttpContextExtensions-ResponseStream.cs
@@ -44,7 +44,7 @@ namespace EmbedIO
         /// <param name="this">The <see cref="IHttpContext" /> on which this method is called.</param>
         /// <param name="encoding">
         /// <para>The <see cref="Encoding"/> to use to convert text to data bytes.</para>
-        /// <para>If <see langword="null"/> (the default), <see cref="Encoding.UTF8">UTF-8</see> is used.</para>
+        /// <para>If <see langword="null"/> (the default), <see cref="WebServer.DefaultEncoding"/> (UTF-8) is used.</para>
         /// </param>
         /// <param name="buffered">If set to <see langword="true" />, sent data is collected
         /// in a <see cref="MemoryStream" /> and sent all at once when the returned <see cref="Stream" />
@@ -58,7 +58,7 @@ namespace EmbedIO
         /// <seealso cref="OpenResponseStream"/>
         public static TextWriter OpenResponseText(this IHttpContext @this, Encoding? encoding = null, bool buffered = false, bool preferCompression = true)
         {
-            encoding ??= Encoding.UTF8;
+            encoding ??= WebServer.DefaultEncoding;
             @this.Response.ContentEncoding = encoding;
             return new StreamWriter(OpenResponseStream(@this, buffered, preferCompression), encoding);
         }

--- a/src/EmbedIO/HttpContextExtensions-Responses.cs
+++ b/src/EmbedIO/HttpContextExtensions-Responses.cs
@@ -80,10 +80,10 @@ namespace EmbedIO
             @this.Response.StatusCode = statusCode;
             @this.Response.StatusDescription = statusDescription;
             @this.Response.ContentType = MimeType.Html;
-            @this.Response.ContentEncoding = Encoding.UTF8;
-            using (var text = @this.OpenResponseText(Encoding.UTF8))
+            @this.Response.ContentEncoding = WebServer.DefaultEncoding;
+            using (var text = @this.OpenResponseText(WebServer.DefaultEncoding))
             {
-                text.Write(StandardHtmlHeaderFormat, statusCode, statusDescription, Encoding.UTF8.WebName);
+                text.Write(StandardHtmlHeaderFormat, statusCode, statusDescription, WebServer.DefaultEncoding.WebName);
                 writeAdditionalHtml?.Invoke(text);
                 text.Write(StandardHtmlFooter);
             }

--- a/src/EmbedIO/HttpExceptionHandler.cs
+++ b/src/EmbedIO/HttpExceptionHandler.cs
@@ -48,7 +48,7 @@ namespace EmbedIO
         /// <param name="httpException">The HTTP exception.</param>
         /// <returns>A <see cref="Task" /> representing the ongoing operation.</returns>
         public static Task PlainTextResponse(IHttpContext context, IHttpException httpException)
-            => context.SendStringAsync(httpException.Message ?? string.Empty, MimeType.PlainText, Encoding.UTF8);
+            => context.SendStringAsync(httpException.Message ?? string.Empty, MimeType.PlainText, WebServer.DefaultEncoding);
 
         /// <summary>
         /// <para>Sends a response with a HTML payload

--- a/src/EmbedIO/Net/Internal/HttpListenerResponse.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerResponse.cs
@@ -33,7 +33,7 @@ namespace EmbedIO.Net.Internal
         }
 
         /// <inheritdoc />
-        public Encoding? ContentEncoding { get; set; } = Encoding.UTF8;
+        public Encoding? ContentEncoding { get; set; } = WebServer.DefaultEncoding;
 
         /// <inheritdoc />
         /// <exception cref="ObjectDisposedException">This instance has been disposed.</exception>
@@ -167,7 +167,7 @@ namespace EmbedIO.Net.Internal
             if (_contentType != null)
             {
                 var contentTypeValue = _contentType.IndexOf("charset=", StringComparison.Ordinal) == -1
-                    ? $"{_contentType}; charset={Encoding.UTF8.WebName}"
+                    ? $"{_contentType}; charset={WebServer.DefaultEncoding.WebName}"
                     : _contentType;
 
                 Headers.Add(HttpHeaderNames.ContentType, contentTypeValue);
@@ -328,8 +328,8 @@ namespace EmbedIO.Net.Internal
         private MemoryStream WriteHeaders()
         {
             var stream = new MemoryStream();
-            var data = Encoding.UTF8.GetBytes(GetHeaderData());
-            var preamble = Encoding.UTF8.GetPreamble();
+            var data = WebServer.DefaultEncoding.GetBytes(GetHeaderData());
+            var preamble = WebServer.DefaultEncoding.GetPreamble();
             stream.Write(preamble, 0, preamble.Length);
             stream.Write(data, 0, data.Length);
 

--- a/src/EmbedIO/Net/Internal/ResponseStream.cs
+++ b/src/EmbedIO/Net/Internal/ResponseStream.cs
@@ -165,7 +165,7 @@ namespace EmbedIO.Net.Internal
             _response.Close();
         }
 
-        private static byte[] GetChunkSizeBytes(int size, bool final) => Encoding.UTF8.GetBytes($"{size:x}\r\n{(final ? "\r\n" : string.Empty)}");
+        private static byte[] GetChunkSizeBytes(int size, bool final) => WebServer.DefaultEncoding.GetBytes($"{size:x}\r\n{(final ? "\r\n" : string.Empty)}");
 
         private MemoryStream? GetHeaders(bool closing)
         {

--- a/src/EmbedIO/Net/Internal/SystemHttpRequest.cs
+++ b/src/EmbedIO/Net/Internal/SystemHttpRequest.cs
@@ -66,25 +66,25 @@ namespace EmbedIO.Net.Internal
         {
             get
             {
-                if (_request.HasEntityBody && _request.ContentType != null)
+                if (!_request.HasEntityBody || _request.ContentType == null)
                 {
-                    var charSet = HeaderUtility.GetCharset(ContentType);
-                    if (charSet != null)
-                    {
-                        try
-                        {
-                            return Encoding.GetEncoding(charSet);
-                        }
-                        catch (ArgumentException)
-                        {
-                        }
-                    }
+                    return WebServer.DefaultEncoding;
                 }
 
-                // Microsoft's implementation returns Encoding.Default,
-                // which is the system's active code page in .NET Framework.
-                // Return UTF-8 instead, like .NET Core's HttpListenerRequest.
-                return Encoding.UTF8;
+                var charSet = HeaderUtility.GetCharset(ContentType);
+                if (string.IsNullOrEmpty(charSet))
+                {
+                    return WebServer.DefaultEncoding;
+                }
+
+                try
+                {
+                    return Encoding.GetEncoding(charSet);
+                }
+                catch (ArgumentException)
+                {
+                    return WebServer.DefaultEncoding;
+                }
             }
         }
 

--- a/src/EmbedIO/WebServer-Constants.cs
+++ b/src/EmbedIO/WebServer-Constants.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 
 namespace EmbedIO
 {
@@ -18,5 +19,11 @@ namespace EmbedIO
         /// The signature string included in <c>Server</c> response headers.
         /// </summary>
         public static readonly string Signature = "EmbedIO/" + Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyInformationalVersionAttribute>().First().InformationalVersion;
+
+        /// <summary>
+        /// The default encoding that is both assumed for requests that do not specify an encoding,
+        /// and used for responses when an encoding is not specified.
+        /// </summary>
+        public static readonly Encoding DefaultEncoding = Encoding.UTF8;
     }
 }

--- a/test/EmbedIO.Tests/ActionModuleTest.cs
+++ b/test/EmbedIO.Tests/ActionModuleTest.cs
@@ -16,7 +16,7 @@ namespace EmbedIO.Tests
         public Task OnAny_ResponseOK()
         {
             void Configure(IWebServer server) => server
-                .OnAny(ctx => ctx.SendStringAsync(Ok, MimeType.PlainText, Encoding.UTF8));
+                .OnAny(ctx => ctx.SendStringAsync(Ok, MimeType.PlainText, WebServer.DefaultEncoding));
 
             async Task Use(HttpClient client)
             {
@@ -33,7 +33,7 @@ namespace EmbedIO.Tests
         public Task OnGet_ResponseOK()
         {
             void Configure(IWebServer server) => server
-                .OnGet(ctx => ctx.SendStringAsync(Ok, MimeType.PlainText, Encoding.UTF8));
+                .OnGet(ctx => ctx.SendStringAsync(Ok, MimeType.PlainText, WebServer.DefaultEncoding));
 
             async Task Use(HttpClient client)
             {
@@ -50,7 +50,7 @@ namespace EmbedIO.Tests
         public Task OnPost_ResponseOK()
         {
             void Configure(IWebServer server) => server
-                .OnPost(ctx => ctx.SendStringAsync(Ok, MimeType.PlainText, Encoding.UTF8));
+                .OnPost(ctx => ctx.SendStringAsync(Ok, MimeType.PlainText, WebServer.DefaultEncoding));
 
             async Task Use(HttpClient client)
             {
@@ -67,7 +67,7 @@ namespace EmbedIO.Tests
         public Task OnPut_ResponseOK()
         {
             void Configure(IWebServer server) => server
-                .OnPut(ctx => ctx.SendStringAsync(Ok, MimeType.PlainText, Encoding.UTF8));
+                .OnPut(ctx => ctx.SendStringAsync(Ok, MimeType.PlainText, WebServer.DefaultEncoding));
 
             async Task Use(HttpClient client)
             {
@@ -84,7 +84,7 @@ namespace EmbedIO.Tests
         public Task OnHead_ResponseOK()
         {
             void Configure(IWebServer server) => server
-                .OnHead(ctx => ctx.SendStringAsync(Ok, MimeType.PlainText, Encoding.UTF8));
+                .OnHead(ctx => ctx.SendStringAsync(Ok, MimeType.PlainText, WebServer.DefaultEncoding));
 
             async Task Use(HttpClient client)
             {
@@ -101,7 +101,7 @@ namespace EmbedIO.Tests
         public Task OnDelete_ResponseOK()
         {
             void Configure(IWebServer server) => server
-                .OnDelete(ctx => ctx.SendStringAsync(Ok, MimeType.PlainText, Encoding.UTF8));
+                .OnDelete(ctx => ctx.SendStringAsync(Ok, MimeType.PlainText, WebServer.DefaultEncoding));
 
             async Task Use(HttpClient client)
             {
@@ -118,7 +118,7 @@ namespace EmbedIO.Tests
         public Task OnOptions_ResponseOK()
         {
             void Configure(IWebServer server) => server
-                .OnOptions(ctx=> ctx.SendStringAsync(Ok, MimeType.PlainText, Encoding.UTF8));
+                .OnOptions(ctx=> ctx.SendStringAsync(Ok, MimeType.PlainText, WebServer.DefaultEncoding));
 
             async Task Use(HttpClient client)
             {
@@ -135,7 +135,7 @@ namespace EmbedIO.Tests
         public Task OnPatch_ResponseOK()
         {
             void Configure(IWebServer server) => server
-                .OnPatch(ctx => ctx.SendStringAsync(Ok, MimeType.PlainText, Encoding.UTF8));
+                .OnPatch(ctx => ctx.SendStringAsync(Ok, MimeType.PlainText, WebServer.DefaultEncoding));
 
             async Task Use(HttpClient client)
             {

--- a/test/EmbedIO.Tests/HttpsTest.cs
+++ b/test/EmbedIO.Tests/HttpsTest.cs
@@ -31,7 +31,7 @@ namespace EmbedIO.Tests
                 .WithMode(HttpListenerMode.EmbedIO);
 
             using var webServer = new WebServer(options);
-            webServer.OnAny(ctx => ctx.SendStringAsync(DefaultMessage, MimeType.PlainText, Encoding.UTF8));
+            webServer.OnAny(ctx => ctx.SendStringAsync(DefaultMessage, MimeType.PlainText, WebServer.DefaultEncoding));
 
             _ = webServer.RunAsync();
 

--- a/test/EmbedIO.Tests/Issues/Issue355_ContentResponseLength.cs
+++ b/test/EmbedIO.Tests/Issues/Issue355_ContentResponseLength.cs
@@ -12,7 +12,7 @@ namespace EmbedIO.Tests.Issues
         {
             const string DefaultUrl = "http://localhost:1234/";
 
-            var ok = Encoding.UTF8.GetBytes("content");
+            var ok = WebServer.DefaultEncoding.GetBytes("content");
 
             using var server = new WebServer(HttpListenerMode.EmbedIO, DefaultUrl);
             server.WithAction("/", HttpVerbs.Get, async context =>
@@ -34,7 +34,7 @@ namespace EmbedIO.Tests.Issues
         [Test]
         public async Task ActionModuleWithHeaderCollection_Handle_ContentLengthProperly()
         {
-            var ok = Encoding.UTF8.GetBytes("content");
+            var ok = WebServer.DefaultEncoding.GetBytes("content");
 
             using var server = new WebServer(1234);
             server.WithAction("/", HttpVerbs.Get, async context =>

--- a/test/EmbedIO.Tests/Issues/Issue389_RequestContentLength.cs
+++ b/test/EmbedIO.Tests/Issues/Issue389_RequestContentLength.cs
@@ -22,7 +22,7 @@ namespace EmbedIO.Tests.Issues
             _ = server.RunAsync();
 
             using var client = new HttpClient();
-            using var content = new StringContent(Content, Encoding.UTF8, "text/plain");
+            using var content = new StringContent(Content, WebServer.DefaultEncoding, "text/plain");
             using var response = await client.PostAsync(DefaultUrl, content).ConfigureAwait(false);
             var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
@@ -43,7 +43,7 @@ namespace EmbedIO.Tests.Issues
             _ = server.RunAsync();
 
             using var client = new HttpClient();
-            using var content = new StringContent(Content, Encoding.UTF8, "text/plain");
+            using var content = new StringContent(Content, WebServer.DefaultEncoding, "text/plain");
             using var response = await client.PostAsync(DefaultUrl, content).ConfigureAwait(false);
             var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/test/EmbedIO.Tests/ResourceFileProviderTest.cs
+++ b/test/EmbedIO.Tests/ResourceFileProviderTest.cs
@@ -33,10 +33,10 @@ namespace EmbedIO.Tests
         public void OpenFile_ReturnsCorrectContent(string urlPath)
         {
             var info = _fileProvider.MapUrlPath(urlPath, _mimeTypeProvider);
-            var expectedText = StockResource.GetText(urlPath, Encoding.UTF8);
+            var expectedText = StockResource.GetText(urlPath, WebServer.DefaultEncoding);
 
             using var stream = _fileProvider.OpenFile(info.Path);
-            using var reader = new StreamReader(stream, Encoding.UTF8, false, WebServer.StreamCopyBufferSize, true);
+            using var reader = new StreamReader(stream, WebServer.DefaultEncoding, false, WebServer.StreamCopyBufferSize, true);
             var actualText = reader.ReadToEnd();
 
             Assert.AreEqual(expectedText, actualText, "Content is the same as embedded resource");

--- a/test/EmbedIO.Tests/TestObjects/TestLocalSessionController.cs
+++ b/test/EmbedIO.Tests/TestObjects/TestLocalSessionController.cs
@@ -22,25 +22,25 @@ namespace EmbedIO.Tests.TestObjects
             var cookie = new System.Net.Cookie(CookieName, CookieName);
             Response.Cookies.Add(cookie);
 
-            return HttpContext.SendStringAsync(Response.Cookies[CookieName].Value, MimeType.PlainText, Encoding.UTF8);
+            return HttpContext.SendStringAsync(Response.Cookies[CookieName].Value, MimeType.PlainText, WebServer.DefaultEncoding);
         }
 
         [Route(HttpVerbs.Get, "/deletesession")]
         public Task DeleteSessionC()
         {
             HttpContext.Session.Delete();
-            return HttpContext.SendStringAsync("Deleted", MimeType.PlainText, Encoding.UTF8);
+            return HttpContext.SendStringAsync("Deleted", MimeType.PlainText, WebServer.DefaultEncoding);
         }
 
         [Route(HttpVerbs.Get, "/putdata")]
         public Task PutDataSession()
         {
             HttpContext.Session["sessionData"] = MyData;
-            return HttpContext.SendStringAsync(HttpContext.Session.GetOrDefault("sessionData", string.Empty), MimeType.PlainText, Encoding.UTF8);
+            return HttpContext.SendStringAsync(HttpContext.Session.GetOrDefault("sessionData", string.Empty), MimeType.PlainText, WebServer.DefaultEncoding);
         }
 
         [Route(HttpVerbs.Get, "/getdata")]
         public Task GetDataSession()
-            => HttpContext.SendStringAsync(HttpContext.Session["sessionData"]?.ToString() ?? string.Empty, MimeType.PlainText, Encoding.UTF8);
+            => HttpContext.SendStringAsync(HttpContext.Session["sessionData"]?.ToString() ?? string.Empty, MimeType.PlainText, WebServer.DefaultEncoding);
     }
 }

--- a/test/EmbedIO.Tests/TestObjects/TestRegexModule.Controller.cs
+++ b/test/EmbedIO.Tests/TestObjects/TestRegexModule.Controller.cs
@@ -11,11 +11,11 @@ namespace EmbedIO.Tests.TestObjects
         {
             [Route(HttpVerbs.Any, "/data/{id}")]
             public Task Id(string id)
-                => HttpContext.SendStringAsync(id, MimeType.PlainText, Encoding.UTF8);
+                => HttpContext.SendStringAsync(id, MimeType.PlainText, WebServer.DefaultEncoding);
 
             [Route(HttpVerbs.Any, "/data/{id}/{time?}")]
             public Task Time(string id, string time)
-                => HttpContext.SendStringAsync(time, MimeType.PlainText, Encoding.UTF8);
+                => HttpContext.SendStringAsync(time, MimeType.PlainText, WebServer.DefaultEncoding);
 
             [Route(HttpVerbs.Any, "/empty")]
             public void Empty()

--- a/test/EmbedIO.Tests/WebApiModuleTest.cs
+++ b/test/EmbedIO.Tests/WebApiModuleTest.cs
@@ -45,7 +45,7 @@ namespace EmbedIO.Tests
                 var model = new Person { Key = 10, Name = "Test" };
                 var payloadJson = new StringContent(
                     Json.Serialize(model),
-                    System.Text.Encoding.UTF8,
+                    WebServer.DefaultEncoding,
                     MimeType.Json);
 
                 var response = await Client.PostAsync("/api/regex", payloadJson);


### PR DESCRIPTION
The new `WebServer.DefaultEncoding` field is now used everywhere in EmbedIO, except for WebSockets, that have their own RFC-mandated encoding.

This PR also fixes the two LGTM warnings generated by #473.