### PR TITLE
Some improvements to HttpListener and associated classes

### DIFF
--- a/src/EmbedIO/Internal/UriUtility.cs
+++ b/src/EmbedIO/Internal/UriUtility.cs
@@ -49,7 +49,7 @@ namespace EmbedIO.Internal
 
         public static Uri StringToUri(string str)
         {
-            Uri.TryCreate(str, CanBeAbsoluteUrl(str) ? UriKind.Absolute : UriKind.Relative, out var result);
+            _ = Uri.TryCreate(str, CanBeAbsoluteUrl(str) ? UriKind.Absolute : UriKind.Relative, out var result);
             return result;
         }
 
@@ -58,7 +58,7 @@ namespace EmbedIO.Internal
             if (!CanBeAbsoluteUrl(str))
                 return null;
 
-            Uri.TryCreate(str, UriKind.Absolute, out var result);
+            _ = Uri.TryCreate(str, UriKind.Absolute, out var result);
             return result;
         }
     }

--- a/src/EmbedIO/Internal/UriUtility.cs
+++ b/src/EmbedIO/Internal/UriUtility.cs
@@ -56,7 +56,9 @@ namespace EmbedIO.Internal
         public static Uri? StringToAbsoluteUri(string str)
         {
             if (!CanBeAbsoluteUrl(str))
+            {
                 return null;
+            }
 
             _ = Uri.TryCreate(str, UriKind.Absolute, out var result);
             return result;

--- a/src/EmbedIO/Internal/UriUtility.cs
+++ b/src/EmbedIO/Internal/UriUtility.cs
@@ -4,49 +4,6 @@ namespace EmbedIO.Internal
 {
     internal static class UriUtility
     {
-        // Returns true if string starts with "http:", "https:", "ws:", or "wss:"
-        public static bool CanBeAbsoluteUrl(string str)
-        {
-            if (string.IsNullOrEmpty(str))
-                return false;
-
-            switch (str[0])
-            {
-                case 'h':
-                    if (str.Length < 5)
-                        return false;
-                    if (str[1] != 't' || str[2] != 't' || str[3] != 'p')
-                        return false;
-                    switch (str[4])
-                    {
-                        case ':':
-                            return true;
-                        case 's':
-                            return str.Length >= 6 && str[5] == ':';
-                        default:
-                            return false;
-                    }
-
-                case 'w':
-                    if (str.Length < 3)
-                        return false;
-                    if (str[1] != 's')
-                        return false;
-                    switch (str[2])
-                    {
-                        case ':':
-                            return true;
-                        case 's':
-                            return str.Length >= 4 && str[3] == ':';
-                        default:
-                            return false;
-                    }
-
-                default:
-                    return false;
-            }
-        }
-
         public static Uri StringToUri(string str)
         {
             _ = Uri.TryCreate(str, CanBeAbsoluteUrl(str) ? UriKind.Absolute : UriKind.Relative, out var result);
@@ -63,5 +20,28 @@ namespace EmbedIO.Internal
             _ = Uri.TryCreate(str, UriKind.Absolute, out var result);
             return result;
         }
+
+        // Returns true if string starts with "http:", "https:", "ws:", or "wss:"
+        private static bool CanBeAbsoluteUrl(string str)
+            => !string.IsNullOrEmpty(str)
+            && str[0] switch {
+                   'h' => str.Length >= 5
+                       && str[1] == 't'
+                       && str[2] == 't'
+                       && str[3] == 'p'
+                       && str[4] switch {
+                              ':' => true,
+                              's' => str.Length >= 6 && str[5] == ':',
+                              _ => false
+                          },
+                   'w' => str.Length >= 3
+                       && str[1] == 's'
+                       && str[2] switch {
+                              ':' => true,
+                              's' => str.Length >= 4 && str[3] == ':',
+                              _ => false
+                          },
+                   _ => false
+               };
     }
 }

--- a/src/EmbedIO/Net/EndPointManager.cs
+++ b/src/EmbedIO/Net/EndPointManager.cs
@@ -55,7 +55,7 @@ namespace EmbedIO.Net
             {
                 if (p.TryRemove(ep.Port, out _) && p.Count == 0)
                 {
-                    IPToEndpoints.TryRemove(ep.Address, out _);
+                    _ = IPToEndpoints.TryRemove(ep.Address, out _);
                 }
             }
 

--- a/src/EmbedIO/Net/EndPointManager.cs
+++ b/src/EmbedIO/Net/EndPointManager.cs
@@ -75,7 +75,9 @@ namespace EmbedIO.Net
             var lp = new ListenerPrefix(p);
 
             if (!lp.IsValid())
+            {
                 throw new HttpListenerException(400, "Invalid path.");
+            }
 
             // listens on all the interfaces if host name cannot be parsed by IPAddress.
             var epl = GetEpListener(lp.Host, lp.Port, listener, lp.Secure);
@@ -93,10 +95,14 @@ namespace EmbedIO.Net
         private static IPAddress ResolveAddress(string host)
         {
             if (host == "*" || host == "+" || host == "0.0.0.0")
+            {
                 return UseIpv6 ? IPAddress.IPv6Any : IPAddress.Any;
+            }
 
-            if (IPAddress.TryParse(host, out var address)) 
+            if (IPAddress.TryParse(host, out var address))
+            {
                 return address;
+            }
 
             try
             {
@@ -120,7 +126,9 @@ namespace EmbedIO.Net
                 var lp = new ListenerPrefix(prefix);
 
                 if (!lp.IsValid())
+                {
                     return;
+                }
 
                 var epl = GetEpListener(lp.Host, lp.Port, listener, lp.Secure);
                 epl.RemovePrefix(lp);

--- a/src/EmbedIO/Net/EndPointManager.cs
+++ b/src/EmbedIO/Net/EndPointManager.cs
@@ -13,8 +13,7 @@ namespace EmbedIO.Net
     /// </summary>
     public static class EndPointManager
     {
-        private static readonly ConcurrentDictionary<IPAddress, ConcurrentDictionary<int, EndPointListener>> IPToEndpoints =
-            new ConcurrentDictionary<IPAddress, ConcurrentDictionary<int, EndPointListener>>();
+        private static readonly ConcurrentDictionary<IPAddress, ConcurrentDictionary<int, EndPointListener>> IPToEndpoints = new ();
 
         /// <summary>
         /// Gets or sets a value indicating whether [use IPv6]. By default, this flag is set.

--- a/src/EmbedIO/Net/HttpListener.cs
+++ b/src/EmbedIO/Net/HttpListener.cs
@@ -87,6 +87,7 @@ namespace EmbedIO.Net
             }
 
             Close(true);
+            _ctxQueueSem.Dispose();
             _disposed = true;
         }
 

--- a/src/EmbedIO/Net/HttpListener.cs
+++ b/src/EmbedIO/Net/HttpListener.cs
@@ -17,7 +17,7 @@ namespace EmbedIO.Net
     /// <seealso cref="IDisposable" />
     public sealed class HttpListener : IHttpListener
     {
-        private readonly SemaphoreSlim _ctxQueueSem = new SemaphoreSlim(0);
+        private readonly SemaphoreSlim _ctxQueueSem = new (0);
         private readonly ConcurrentDictionary<string, HttpListenerContext> _ctxQueue;
         private readonly ConcurrentDictionary<HttpConnection, object> _connections;
         private readonly HttpListenerPrefixCollection _prefixes;

--- a/src/EmbedIO/Net/HttpListener.cs
+++ b/src/EmbedIO/Net/HttpListener.cs
@@ -60,7 +60,9 @@ namespace EmbedIO.Net
         public void Start()
         {
             if (IsListening)
+            {
                 return;
+            }
 
             EndPointManager.AddListener(this);
             IsListening = true;
@@ -80,7 +82,9 @@ namespace EmbedIO.Net
         public void Dispose()
         {
             if (_disposed)
+            {
                 return;
+            }
 
             Close(true);
             _disposed = true;
@@ -108,7 +112,9 @@ namespace EmbedIO.Net
         internal void RegisterContext(HttpListenerContext context)
         {
             if (!_ctxQueue.TryAdd(context.Id, context))
+            {
                 throw new InvalidOperationException("Unable to register context");
+            }
 
             _ = _ctxQueueSem.Release();
         }
@@ -130,16 +136,23 @@ namespace EmbedIO.Net
             var list = new List<HttpConnection>(connections);
 
             for (var i = list.Count - 1; i >= 0; i--)
+            {
                 list[i].Close(true);
+            }
 
-            if (!closeExisting) return;
+            if (!closeExisting)
+            {
+                return;
+            }
 
             while (!_ctxQueue.IsEmpty)
             {
                 foreach (var key in _ctxQueue.Keys.ToArray())
                 {
                     if (_ctxQueue.TryGetValue(key, out var context))
+                    {
                         context.Connection.Close(true);
+                    }
                 }
             }
         }

--- a/src/EmbedIO/Net/HttpListener.cs
+++ b/src/EmbedIO/Net/HttpListener.cs
@@ -110,7 +110,7 @@ namespace EmbedIO.Net
             if (!_ctxQueue.TryAdd(context.Id, context))
                 throw new InvalidOperationException("Unable to register context");
 
-            _ctxQueueSem.Release();
+            _ = _ctxQueueSem.Release();
         }
 
         internal void UnregisterContext(HttpListenerContext context) => _ctxQueue.TryRemove(context.Id, out _);

--- a/src/EmbedIO/Net/Internal/EndPointListener.cs
+++ b/src/EmbedIO/Net/Internal/EndPointListener.cs
@@ -176,23 +176,15 @@ namespace EmbedIO.Net.Internal
             do
             {
                 prefs = _prefixes;
-                ListenerPrefix lpKey = null;
-                foreach (var p in _prefixes.Keys)
-                {
-                    if (p.Path == prefix.Path)
-                    {
-                        lpKey = p;
-                        break;
-                    }
-                }
+                var prefixKey = _prefixes.Keys.FirstOrDefault(p => p.Path == prefix.Path);
 
-                if (lpKey is null)
+                if (prefixKey is null)
                 {
                     break;
                 }
 
                 p2 = prefs.ToDictionary(x => x.Key, x => x.Value);
-                _ = p2.Remove(lpKey);
+                _ = p2.Remove(prefixKey);
             }
             while (Interlocked.CompareExchange(ref _prefixes, p2, prefs) != prefs);
 
@@ -210,11 +202,11 @@ namespace EmbedIO.Net.Internal
         private static void Accept(Socket socket, SocketAsyncEventArgs e, ref Socket? accepted)
         {
             e.AcceptSocket = null;
-            bool asyn;
+            bool acceptPending;
 
             try
             {
-                asyn = socket.AcceptAsync(e);
+                acceptPending = socket.AcceptAsync(e);
             }
             catch
             {
@@ -228,11 +220,10 @@ namespace EmbedIO.Net.Internal
                 }
 
                 accepted = null;
-
                 return;
             }
 
-            if (!asyn)
+            if (!acceptPending)
             {
                 ProcessAccept(e);
             }

--- a/src/EmbedIO/Net/Internal/EndPointListener.cs
+++ b/src/EmbedIO/Net/Internal/EndPointListener.cs
@@ -24,7 +24,9 @@ namespace EmbedIO.Net.Internal
             _sock = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             
             if (address.AddressFamily == AddressFamily.InterNetworkV6 && EndPointManager.UseIpv6)
+            {
                 _sock.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
+            }
 
             _sock.Bind(_endpoint);
             _sock.Listen(500);
@@ -46,7 +48,9 @@ namespace EmbedIO.Net.Internal
             var listener = SearchListener(req.Url, out var prefix);
 
             if (listener == null)
+            {
                 return false;
+            }
 
             context.Listener = listener;
             context.Connection.Prefix = prefix;
@@ -74,7 +78,9 @@ namespace EmbedIO.Net.Internal
             }
 
             foreach (var c in connections)
+            {
                 c.Dispose();
+            }
         }
 
         public void AddPrefix(ListenerPrefix prefix, HttpListener listener)
@@ -118,9 +124,11 @@ namespace EmbedIO.Net.Internal
                 prefs = _prefixes;
                 if (prefs.ContainsKey(prefix))
                 {
-                    var other = prefs[prefix];
-                    if (other != listener)
+                    if (prefs[prefix] != listener)
+                    {
                         throw new HttpListenerException(400, $"There is another listener for {prefix}");
+                    }
+
                     return;
                 }
 
@@ -142,7 +150,9 @@ namespace EmbedIO.Net.Internal
                     current = _unhandled;
                     future = current?.ToList() ?? new List<ListenerPrefix>();
                     if (!RemoveSpecial(future, prefix))
+                    {
                         break; // Prefix not found
+                    }
                 }
                 while (Interlocked.CompareExchange(ref _unhandled, future, current) != current);
 
@@ -157,7 +167,9 @@ namespace EmbedIO.Net.Internal
                     current = _all;
                     future = current?.ToList() ?? new List<ListenerPrefix>();
                     if (!RemoveSpecial(future, prefix))
+                    {
                         break; // Prefix not found
+                    }
                 }
                 while (Interlocked.CompareExchange(ref _all, future, current) != current);
 
@@ -181,7 +193,9 @@ namespace EmbedIO.Net.Internal
                 }
 
                 if (lpKey is null)
+                {
                     break;
+                }
 
                 p2 = prefs.ToDictionary(x => x.Key, x => x.Value);
                 _ = p2.Remove(lpKey);
@@ -234,13 +248,17 @@ namespace EmbedIO.Net.Internal
         {
             Socket? accepted = null;
             if (args.SocketError == SocketError.Success)
+            {
                 accepted = args.AcceptSocket;
+            }
 
             var epl = (EndPointListener)args.UserToken;
 
             Accept(epl._sock, args, ref accepted);
             if (accepted == null)
+            {
                 return;
+            }
 
             if (epl.Secure && epl.Listener.Certificate == null)
             {
@@ -272,14 +290,19 @@ namespace EmbedIO.Net.Internal
         {
             prefix = null;
             if (list == null)
+            {
                 return null;
+            }
 
             HttpListener? bestMatch = null;
             var bestLength = -1;
 
             foreach (var p in list)
             {
-                if (p.Path.Length < bestLength || !path.StartsWith(p.Path)) continue;
+                if (p.Path.Length < bestLength || !path.StartsWith(p.Path))
+                {
+                    continue;
+                }
 
                 bestLength = p.Path.Length;
                 bestMatch = p.Listener;
@@ -292,7 +315,9 @@ namespace EmbedIO.Net.Internal
         private static void AddSpecial(ICollection<ListenerPrefix> coll, ListenerPrefix prefix)
         {
             if (coll == null)
+            {
                 return;
+            }
 
             if (coll.Any(p => p.Path == prefix.Path))
             {
@@ -305,12 +330,17 @@ namespace EmbedIO.Net.Internal
         private static bool RemoveSpecial(IList<ListenerPrefix> coll, ListenerPrefix prefix)
         {
             if (coll == null)
+            {
                 return false;
+            }
 
             var c = coll.Count;
             for (var i = 0; i < c; i++)
             {
-                if (coll[i].Path != prefix.Path) continue;
+                if (coll[i].Path != prefix.Path)
+                {
+                    continue;
+                }
 
                 coll.RemoveAt(i);
                 return true;
@@ -323,7 +353,9 @@ namespace EmbedIO.Net.Internal
         {
             prefix = null;
             if (uri == null)
+            {
                 return null;
+            }
 
             var host = uri.Host;
             var port = uri.Port;
@@ -340,13 +372,19 @@ namespace EmbedIO.Net.Internal
                 foreach (var p in result.Keys)
                 {
                     if (p.Path.Length < bestLength)
+                    {
                         continue;
+                    }
 
                     if (p.Host != host || p.Port != port)
+                    {
                         continue;
+                    }
 
                     if (!path.StartsWith(p.Path) && !pathSlash.StartsWith(p.Path))
+                    {
                         continue;
+                    }
 
                     bestLength = p.Path.Length;
                     bestMatch = result[p];
@@ -354,20 +392,29 @@ namespace EmbedIO.Net.Internal
                 }
 
                 if (bestLength != -1)
+                {
                     return bestMatch;
+                }
             }
 
             var list = _unhandled;
             bestMatch = MatchFromList(path, list, out prefix);
             if (path != pathSlash && bestMatch == null)
+            {
                 bestMatch = MatchFromList(pathSlash, list, out prefix);
+            }
+
             if (bestMatch != null)
+            {
                 return bestMatch;
+            }
 
             list = _all;
             bestMatch = MatchFromList(path, list, out prefix);
             if (path != pathSlash && bestMatch == null)
+            {
                 bestMatch = MatchFromList(pathSlash, list, out prefix);
+            }
 
             return bestMatch;
         }
@@ -375,15 +422,21 @@ namespace EmbedIO.Net.Internal
         private void CheckIfRemove()
         {
             if (_prefixes.Count > 0)
+            {
                 return;
+            }
 
             var list = _unhandled;
             if (list != null && list.Count > 0)
+            {
                 return;
+            }
 
             list = _all;
             if (list != null && list.Count > 0)
+            {
                 return;
+            }
 
             EndPointManager.RemoveEndPoint(this, _endpoint);
         }

--- a/src/EmbedIO/Net/Internal/EndPointListener.cs
+++ b/src/EmbedIO/Net/Internal/EndPointListener.cs
@@ -57,13 +57,7 @@ namespace EmbedIO.Net.Internal
             return true;
         }
 
-        public void UnbindContext(HttpListenerContext context)
-        {
-            if (context?.Request == null)
-                return;
-
-            context.Listener.UnregisterContext(context);
-        }
+        public void UnbindContext(HttpListenerContext context) => context.Listener.UnregisterContext(context);
 
         public void Dispose()
         {

--- a/src/EmbedIO/Net/Internal/EndPointListener.cs
+++ b/src/EmbedIO/Net/Internal/EndPointListener.cs
@@ -251,7 +251,7 @@ namespace EmbedIO.Net.Internal
             HttpConnection conn;
             try
             {
-                conn = new HttpConnection(accepted, epl, epl.Listener.Certificate);
+                conn = new HttpConnection(accepted, epl);
             }
             catch
             {

--- a/src/EmbedIO/Net/Internal/EndPointListener.cs
+++ b/src/EmbedIO/Net/Internal/EndPointListener.cs
@@ -299,7 +299,7 @@ namespace EmbedIO.Net.Internal
 
             foreach (var p in list)
             {
-                if (p.Path.Length < bestLength || !path.StartsWith(p.Path))
+                if (p.Path.Length < bestLength || !path.StartsWith(p.Path, StringComparison.Ordinal))
                 {
                     continue;
                 }
@@ -381,7 +381,7 @@ namespace EmbedIO.Net.Internal
                         continue;
                     }
 
-                    if (!path.StartsWith(p.Path) && !pathSlash.StartsWith(p.Path))
+                    if (!path.StartsWith(p.Path, StringComparison.Ordinal) && !pathSlash.StartsWith(p.Path, StringComparison.Ordinal))
                     {
                         continue;
                     }

--- a/src/EmbedIO/Net/Internal/HttpConnection.cs
+++ b/src/EmbedIO/Net/Internal/HttpConnection.cs
@@ -92,7 +92,10 @@ namespace EmbedIO.Net.Internal
             try
             {
                 if (Reuses == 1)
+                {
                     _sTimeout = 15000;
+                }
+
                 _ = _timer.Change(_sTimeout, Timeout.Infinite);
 
                 var data = await Stream.ReadAsync(_buffer, 0, BufferSize).ConfigureAwait(false);
@@ -133,7 +136,10 @@ namespace EmbedIO.Net.Internal
                 _oStream = null;
             }
 
-            if (_sock == null) return;
+            if (_sock == null)
+            {
+                return;
+            }
 
             forceClose = forceClose
                       || !_context.Request.KeepAlive
@@ -268,10 +274,14 @@ namespace EmbedIO.Net.Internal
             while (true)
             {
                 if (_errorMessage != null)
+                {
                     return true;
+                }
 
                 if (_position >= len)
+                {
                     break;
+                }
 
                 string? line;
                 try
@@ -286,12 +296,17 @@ namespace EmbedIO.Net.Internal
                 }
 
                 if (line == null)
+                {
                     break;
+                }
 
                 if (string.IsNullOrEmpty(line))
                 {
                     if (_inputState == InputState.RequestLine)
+                    {
                         continue;
+                    }
+
                     _currentLine = null;
 
                     return true;

--- a/src/EmbedIO/Net/Internal/HttpConnection.cs
+++ b/src/EmbedIO/Net/Internal/HttpConnection.cs
@@ -31,7 +31,7 @@ namespace EmbedIO.Net.Internal
         private int _position;
         private string? _errorMessage;
 
-        public HttpConnection(Socket sock, EndPointListener epl, X509Certificate cert)
+        public HttpConnection(Socket sock, EndPointListener epl)
         {
             _sock = sock;
             _epl = epl;
@@ -39,17 +39,14 @@ namespace EmbedIO.Net.Internal
             LocalEndPoint = (IPEndPoint) sock.LocalEndPoint;
             RemoteEndPoint = (IPEndPoint) sock.RemoteEndPoint;
 
-            if (!IsSecure)
+            Stream = new NetworkStream(sock, false);
+            if (IsSecure)
             {
-                Stream = new NetworkStream(sock, false);
-            }
-            else
-            {
-                var sslStream = new SslStream(new NetworkStream(sock, false), true);
+                var sslStream = new SslStream(Stream, true);
 
                 try
                 {
-                    sslStream.AuthenticateAsServer(cert);
+                    sslStream.AuthenticateAsServer(epl.Listener.Certificate);
                 }
                 catch
                 {

--- a/src/EmbedIO/Net/Internal/HttpConnection.cs
+++ b/src/EmbedIO/Net/Internal/HttpConnection.cs
@@ -12,7 +12,7 @@ namespace EmbedIO.Net.Internal
 {
     internal sealed partial class HttpConnection : IDisposable
     {
-        internal const int BufferSize = 8192;
+        private const int BufferSize = 8192;
 
         private readonly Timer _timer;
         private readonly EndPointListener _epl;

--- a/src/EmbedIO/Net/Internal/HttpConnection.cs
+++ b/src/EmbedIO/Net/Internal/HttpConnection.cs
@@ -93,14 +93,14 @@ namespace EmbedIO.Net.Internal
             {
                 if (Reuses == 1)
                     _sTimeout = 15000;
-                _timer.Change(_sTimeout, Timeout.Infinite);
+                _ = _timer.Change(_sTimeout, Timeout.Infinite);
 
                 var data = await Stream.ReadAsync(_buffer, 0, BufferSize).ConfigureAwait(false);
                 await OnReadInternal(data).ConfigureAwait(false);
             }
             catch
             {
-                _timer.Change(Timeout.Infinite, Timeout.Infinite);
+                _ = _timer.Change(Timeout.Infinite, Timeout.Infinite);
                 CloseSocket();
                 Unbind();
             }
@@ -144,9 +144,7 @@ namespace EmbedIO.Net.Internal
                     Reuses++;
                     Unbind();
                     Init();
-#pragma warning disable 4014
-                    BeginReadRequest();
-#pragma warning restore 4014
+                    _ = BeginReadRequest();
                     return;
                 }
             }
@@ -189,7 +187,7 @@ namespace EmbedIO.Net.Internal
 
         private async Task OnReadInternal(int offset)
         {
-            _timer.Change(Timeout.Infinite, Timeout.Infinite);
+            _ = _timer.Change(Timeout.Infinite, Timeout.Infinite);
 
             // Continue reading until full header is received.
             // Especially important for multipart requests when the second part of the header arrives after a tiny delay
@@ -346,7 +344,7 @@ namespace EmbedIO.Net.Internal
                         _lineState = LineState.Lf;
                         break;
                     default:
-                        _currentLine.Append((char)b);
+                        _ = _currentLine.Append((char)b);
                         break;
                 }
             }

--- a/src/EmbedIO/Net/Internal/HttpConnection.cs
+++ b/src/EmbedIO/Net/Internal/HttpConnection.cs
@@ -349,17 +349,23 @@ namespace EmbedIO.Net.Internal
                 }
             }
 
-            if (_lineState != LineState.Lf) return null;
+            if (_lineState != LineState.Lf)
+            {
+                return null;
+            }
+
             _lineState = LineState.None;
             var result = _currentLine.ToString();
             _currentLine.Length = 0;
-
             return result;
         }
 
         private void Unbind()
         {
-            if (!_contextBound) return;
+            if (!_contextBound)
+            {
+                return;
+            }
 
             _epl.UnbindContext(_context);
             _contextBound = false;
@@ -368,7 +374,9 @@ namespace EmbedIO.Net.Internal
         private void CloseSocket()
         {
             if (_sock == null)
+            {
                 return;
+            }
 
             try
             {

--- a/src/EmbedIO/Net/Internal/HttpConnection.cs
+++ b/src/EmbedIO/Net/Internal/HttpConnection.cs
@@ -121,6 +121,8 @@ namespace EmbedIO.Net.Internal
 
         public ResponseStream GetResponseStream() => _oStream ??= new ResponseStream(Stream, _context.HttpListenerResponse, _context.Listener?.IgnoreWriteExceptions ?? true);
 
+        internal void SetError(string message) => _errorMessage = message;
+
         internal void ForceClose() => Close(true);
 
         internal void Close(bool forceClose = false)

--- a/src/EmbedIO/Net/Internal/HttpConnection.cs
+++ b/src/EmbedIO/Net/Internal/HttpConnection.cs
@@ -61,10 +61,6 @@ namespace EmbedIO.Net.Internal
             Init();
         }
 
-        ~HttpConnection()
-        {
-            Dispose(false);
-        }
 
         public int Reuses { get; private set; }
 
@@ -80,8 +76,15 @@ namespace EmbedIO.Net.Internal
 
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
+            Close(true);
+
+            _timer.Dispose();
+            _sock?.Dispose();
+            _ms?.Dispose();
+            _iStream?.Dispose();
+            _oStream?.Dispose();
+            Stream?.Dispose();
+            _lastListener?.Dispose();
         }
 
         public async Task BeginReadRequest()
@@ -405,23 +408,6 @@ namespace EmbedIO.Net.Internal
             }
 
             RemoveConnection();
-        }
-
-        private void Dispose(bool disposing)
-        {
-            Close(true);
-
-            if (!disposing)
-                return;
-
-            _timer?.Dispose();
-            _sock?.Dispose();
-            _ms?.Dispose();
-            _iStream?.Dispose();
-            _oStream?.Dispose();
-            Stream?.Dispose();
-            _lastListener?.Dispose();
-            ClientCertificate?.Dispose();
         }
     }
 }

--- a/src/EmbedIO/Net/Internal/HttpConnection.cs
+++ b/src/EmbedIO/Net/Internal/HttpConnection.cs
@@ -81,8 +81,6 @@ namespace EmbedIO.Net.Internal
 
         public ListenerPrefix? Prefix { get; set; }
 
-        internal X509Certificate2? ClientCertificate { get; }
-
         public void Dispose()
         {
             Dispose(true);

--- a/src/EmbedIO/Net/Internal/HttpListenerContext.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerContext.cs
@@ -76,10 +76,6 @@ namespace EmbedIO.Net.Internal
 
         internal HttpListener? Listener { get; set; }
 
-        internal string? ErrorMessage { get; set; }
-
-        internal bool HaveError => ErrorMessage != null;
-
         internal HttpConnection Connection { get; }
 
         public void SetHandled() => IsHandled = true;

--- a/src/EmbedIO/Net/Internal/HttpListenerContext.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerContext.cs
@@ -30,9 +30,9 @@ namespace EmbedIO.Net.Internal
         internal HttpListenerContext(HttpConnection cnc)
         {
             Connection = cnc;
-            Request = new HttpListenerRequest(this);
+            HttpListenerRequest = new HttpListenerRequest(this);
             User = Auth.NoUser;
-            Response = new HttpListenerResponse(this);
+            HttpListenerResponse = new HttpListenerResponse(this);
             Id = UniqueIdGenerator.GetNext();
             LocalEndPoint = Request.LocalEndPoint;
             RemoteEndPoint = Request.RemoteEndPoint;
@@ -50,13 +50,13 @@ namespace EmbedIO.Net.Internal
 
         public IPEndPoint RemoteEndPoint { get; }
 
-        public IHttpRequest Request { get; }
+        public IHttpRequest Request => HttpListenerRequest;
 
         public RouteMatch Route { get; set; }
 
         public string RequestedPath => Route.SubPath ?? string.Empty; // It will never be empty, because modules are matched via base routes - this is just to silence a warning.
 
-        public IHttpResponse Response { get; }
+        public IHttpResponse Response => HttpListenerResponse;
 
         public IPrincipal User { get; set;  }
 
@@ -70,9 +70,9 @@ namespace EmbedIO.Net.Internal
 
         public MimeTypeProviderStack MimeTypeProviders { get; } = new MimeTypeProviderStack();
 
-        internal HttpListenerRequest HttpListenerRequest => Request as HttpListenerRequest;
+        internal HttpListenerRequest HttpListenerRequest { get; }
 
-        internal HttpListenerResponse HttpListenerResponse => Response as HttpListenerResponse;
+        internal HttpListenerResponse HttpListenerResponse { get; }
 
         internal HttpListener? Listener { get; set; }
 

--- a/src/EmbedIO/Net/Internal/HttpListenerContext.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerContext.cs
@@ -83,7 +83,9 @@ namespace EmbedIO.Net.Internal
         public void OnClose(Action<IHttpContext> callback)
         {
             if (_closed)
+            {
                 throw new InvalidOperationException("HTTP context has already been closed.");
+            }
 
             _closeCallbacks.Push(Validate.NotNull(nameof(callback), callback));
         }

--- a/src/EmbedIO/Net/Internal/HttpListenerContext.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerContext.cs
@@ -18,12 +18,11 @@ namespace EmbedIO.Net.Internal
     // Provides access to the request and response objects used by the HttpListener class.
     internal sealed class HttpListenerContext : IHttpContextImpl
     {
-        private readonly Lazy<IDictionary<object, object>> _items =
-            new Lazy<IDictionary<object, object>>(() => new Dictionary<object, object>(), true);
+        private readonly Lazy<IDictionary<object, object>> _items = new (() => new Dictionary<object, object>(), true);
 
-        private readonly TimeKeeper _ageKeeper = new TimeKeeper();
+        private readonly TimeKeeper _ageKeeper = new ();
 
-        private readonly Stack<Action<IHttpContext>> _closeCallbacks = new Stack<Action<IHttpContext>>();
+        private readonly Stack<Action<IHttpContext>> _closeCallbacks = new ();
 
         private bool _closed;
 

--- a/src/EmbedIO/Net/Internal/HttpListenerPrefixCollection.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerPrefixCollection.cs
@@ -15,12 +15,16 @@ namespace EmbedIO.Net.Internal
         {
             ListenerPrefix.CheckUri(uriPrefix);
             if (Contains(uriPrefix))
+            {
                 return;
+            }
 
             base.Add(uriPrefix);
 
             if (_listener.IsListening)
+            {
                 EndPointManager.AddPrefix(uriPrefix, _listener);
+            }
         }
     }
 }

--- a/src/EmbedIO/Net/Internal/HttpListenerRequest.GccDelegate.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerRequest.GccDelegate.cs
@@ -1,9 +1,0 @@
-﻿using System.Security.Cryptography.X509Certificates;
-
-namespace EmbedIO.Net.Internal
-{
-    partial class HttpListenerRequest
-    {
-        private delegate X509Certificate2 GccDelegate();
-    }
-}

--- a/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
@@ -193,7 +193,9 @@ namespace EmbedIO.Net.Internal
                 ProtocolVersion = new Version(parts[2].Substring(5));
 
                 if (ProtocolVersion.Major < 1)
+                {
                     throw new InvalidOperationException();
+                }
             }
             catch
             {
@@ -214,11 +216,15 @@ namespace EmbedIO.Net.Internal
             var path = rawUri?.PathAndQuery ?? RawUrl;
 
             if (string.IsNullOrEmpty(host))
+            {
                 host = rawUri?.Host ?? UserHostAddress;
+            }
 
             var colon = host.LastIndexOf(':');
             if (colon >= 0)
+            {
                 host = host.Substring(0, colon);
+            }
 
             // var baseUri = $"{(IsSecureConnection ? "https" : "http")}://{host}:{LocalEndPoint.Port}";
             var baseUri = $"http://{host}:{LocalEndPoint.Port}";
@@ -232,7 +238,9 @@ namespace EmbedIO.Net.Internal
             InitializeQueryString(Url.Query);
             
             if (ContentLength64 == 0 && (HttpVerb == HttpVerbs.Post || HttpVerb == HttpVerbs.Put))
+            {
                 return;
+            }
 
             if (string.Compare(Headers["Expect"], "100-continue", StringComparison.OrdinalIgnoreCase) == 0)
             {
@@ -266,7 +274,9 @@ namespace EmbedIO.Net.Internal
                     Headers[HttpHeaderNames.ContentLength] = val.Trim();
                     
                     if (ContentLength64 < 0)
+                    {
                         _connection.SetError("Invalid Content-Length.");
+                    }
 
                     break;
                 case "referer":
@@ -291,11 +301,15 @@ namespace EmbedIO.Net.Internal
         internal bool FlushInput()
         {
             if (!HasEntityBody)
+            {
                 return true;
+            }
 
             var length = 2048;
             if (ContentLength64 > 0)
+            {
                 length = (int)Math.Min(ContentLength64, length);
+            }
 
             var bytes = new byte[length];
 
@@ -303,10 +317,10 @@ namespace EmbedIO.Net.Internal
             {
                 try
                 {
-                    var data = InputStream.Read(bytes, 0, length);
-
-                    if (data <= 0)
+                    if (InputStream.Read(bytes, 0, length) <= 0)
+                    {
                         return true;
+                    }
                 }
                 catch (ObjectDisposedException)
                 {
@@ -458,7 +472,9 @@ namespace EmbedIO.Net.Internal
             }
 
             if (query[0] == '?')
+            {
                 query = query.Substring(1);
+            }
 
             var components = query.Split('&');
 

--- a/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
@@ -127,7 +127,7 @@ namespace EmbedIO.Net.Internal
         public Version ProtocolVersion { get; private set; } = HttpVersion.Version11;
 
         /// <inheritdoc />
-        public NameValueCollection? QueryString { get; private set; }
+        public NameValueCollection QueryString { get; } = new ();
 
         /// <inheritdoc />
         public string RawUrl { get; private set; }
@@ -268,7 +268,7 @@ namespace EmbedIO.Net.Internal
                 return;
             }
 
-            CreateQueryString(_url.Query);
+            InitializeQueryString(Url.Query);
             
             if (ContentLength64 == 0 && (HttpVerb == HttpVerbs.Post || HttpVerb == HttpVerbs.Put))
                 return;
@@ -489,15 +489,13 @@ namespace EmbedIO.Net.Internal
             }
         }
 
-        private void CreateQueryString(string query)
+        private void InitializeQueryString(string query)
         {
             if (string.IsNullOrEmpty(query))
             {
-                QueryString = new NameValueCollection(1);
                 return;
             }
 
-            QueryString = new NameValueCollection();
             if (query[0] == '?')
                 query = query.Substring(1);
 

--- a/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
@@ -105,15 +105,16 @@ namespace EmbedIO.Net.Internal
         {
             get
             {
-                if (_kaSet)
-                    return _keepAlive;
+                if (!_kaSet)
+                {
+                    var cnc = Headers.GetValues(HttpHeaderNames.Connection);
+                    _keepAlive = ProtocolVersion < HttpVersion.Version11
+                        ? cnc != null && cnc.Length == 1 && string.Compare(cnc[0], "keep-alive", StringComparison.OrdinalIgnoreCase) == 0
+                        : cnc == null || cnc.All(s => string.Compare(s, "close", StringComparison.OrdinalIgnoreCase) != 0);
 
-                var cnc = Headers.GetValues(HttpHeaderNames.Connection);
-                _keepAlive = ProtocolVersion < HttpVersion.Version11
-                    ? cnc != null && cnc.Length == 1 && string.Compare(cnc[0], "keep-alive", StringComparison.OrdinalIgnoreCase) == 0
-                    : cnc == null || cnc.All(s => string.Compare(s, "close", StringComparison.OrdinalIgnoreCase) != 0);
+                    _kaSet = true;
+                }
 
-                _kaSet = true;
                 return _keepAlive;
             }
         }
@@ -418,19 +419,19 @@ namespace EmbedIO.Net.Internal
 
             foreach (var str in cookieStrings)
             {
-                if (str.StartsWith("$Version"))
+                if (str.StartsWith("$Version", StringComparison.Ordinal))
                 {
                     version = int.Parse(str.Substring(str.IndexOf('=') + 1).Unquote(), CultureInfo.InvariantCulture);
                 }
-                else if (str.StartsWith("$Path") && current != null)
+                else if (str.StartsWith("$Path", StringComparison.Ordinal) && current != null)
                 {
                     current.Path = str.Substring(str.IndexOf('=') + 1).Trim();
                 }
-                else if (str.StartsWith("$Domain") && current != null)
+                else if (str.StartsWith("$Domain", StringComparison.Ordinal) && current != null)
                 {
                     current.Domain = str.Substring(str.IndexOf('=') + 1).Trim();
                 }
-                else if (str.StartsWith("$Port") && current != null)
+                else if (str.StartsWith("$Port", StringComparison.Ordinal) && current != null)
                 {
                     current.Port = str.Substring(str.IndexOf('=') + 1).Trim();
                 }

--- a/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
@@ -183,7 +183,7 @@ namespace EmbedIO.Net.Internal
             HttpVerb = IsKnownHttpMethod(HttpMethod, out var verb) ? verb : HttpVerbs.Any;
 
             RawUrl = parts[1];
-            if (parts[2].Length != 8 || !parts[2].StartsWith("HTTP/"))
+            if (parts[2].Length != 8 || !parts[2].StartsWith("HTTP/", StringComparison.Ordinal))
             {
                 _connection.SetError("Invalid request line (missing HTTP version).");
                 return;

--- a/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
@@ -32,7 +32,6 @@ namespace EmbedIO.Net.Internal
         {
             _context = context;
             Headers = new NameValueCollection();
-            ProtocolVersion = HttpVersion.Version10;
         }
 
         /// <summary>
@@ -125,7 +124,7 @@ namespace EmbedIO.Net.Internal
         public IPEndPoint LocalEndPoint => _context.Connection.LocalEndPoint;
 
         /// <inheritdoc />
-        public Version ProtocolVersion { get; private set; }
+        public Version ProtocolVersion { get; private set; } = HttpVersion.Version11;
 
         /// <inheritdoc />
         public NameValueCollection? QueryString { get; private set; }

--- a/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
@@ -138,7 +138,7 @@ namespace EmbedIO.Net.Internal
         public Uri? Url => _url;
 
         /// <inheritdoc />
-        public Uri UrlReferrer { get; private set; }
+        public Uri? UrlReferrer { get; private set; }
 
         /// <inheritdoc />
         public string UserAgent => Headers[HttpHeaderNames.UserAgent];
@@ -287,7 +287,7 @@ namespace EmbedIO.Net.Internal
                     }
                     catch
                     {
-                        UrlReferrer = new Uri("http://someone.is.screwing.with.the.headers.com/");
+                        UrlReferrer = null;
                     }
 
                     break;

--- a/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
@@ -26,8 +26,6 @@ namespace EmbedIO.Net.Internal
         private bool _kaSet;
         private bool _keepAlive;
 
-        private GccDelegate? _gccDelegate;
-
         internal HttpListenerRequest(HttpListenerContext context)
         {
             Headers = new NameValueCollection();
@@ -157,43 +155,6 @@ namespace EmbedIO.Net.Internal
             && Headers.Contains(HttpHeaderNames.Upgrade, "websocket")
             && Headers.Contains(HttpHeaderNames.Connection, "Upgrade");
 
-        /// <summary>
-        /// Begins to the get client certificate asynchronously.
-        /// </summary>
-        /// <param name="requestCallback">The request callback.</param>
-        /// <param name="state">The state.</param>
-        /// <returns>An async result.</returns>
-        public IAsyncResult? BeginGetClientCertificate(AsyncCallback requestCallback, object state)
-        {
-            if (_gccDelegate == null)
-                _gccDelegate = GetClientCertificate;
-
-            return _gccDelegate?.BeginInvoke(requestCallback, state);
-        }
-
-        /// <summary>
-        /// Finishes the get client certificate asynchronous operation.
-        /// </summary>
-        /// <param name="asyncResult">The asynchronous result.</param>
-        /// <returns>The certificate from the client.</returns>
-        /// <exception cref="System.ArgumentNullException">asyncResult.</exception>
-        /// <exception cref="System.InvalidOperationException"></exception>
-        public X509Certificate2 EndGetClientCertificate(IAsyncResult asyncResult)
-        {
-            if (asyncResult == null)
-                throw new ArgumentNullException(nameof(asyncResult));
-
-            if (_gccDelegate == null)
-                throw new InvalidOperationException();
-
-            return _gccDelegate.EndInvoke(asyncResult);
-        }
-
-        /// <summary>
-        /// Gets the client certificate.
-        /// </summary>
-        /// <returns>The client certificate.</returns>
-        public X509Certificate2? GetClientCertificate() => _connection.ClientCertificate;
 
         internal void SetRequestLine(string req)
         {

--- a/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerRequest.cs
@@ -409,8 +409,7 @@ namespace EmbedIO.Net.Internal
 
         private void ParseCookies(string val)
         {
-            if (_cookies == null)
-                _cookies = new CookieList();
+            _cookies ??= new CookieList();
 
             var cookieStrings = val.SplitByAny(';', ',')
                 .Where(x => !string.IsNullOrEmpty(x));

--- a/src/EmbedIO/Net/Internal/HttpListenerResponse.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerResponse.cs
@@ -47,8 +47,10 @@ namespace EmbedIO.Net.Internal
             {
                 EnsureCanChangeHeaders();
                 if (value < 0)
+                {
                     throw new ArgumentOutOfRangeException(nameof(value), "Must be >= 0");
-                
+                }
+
                 Headers[HttpHeaderNames.ContentLength] = value.ToString(CultureInfo.InvariantCulture);
             }
         }
@@ -118,7 +120,9 @@ namespace EmbedIO.Net.Internal
             {
                 EnsureCanChangeHeaders();
                 if (value < 100 || value > 999)
+                {
                     throw new ArgumentOutOfRangeException(nameof(StatusCode), "StatusCode must be between 100 and 999.");
+                }
 
                 _statusCode = value;
                 StatusDescription = HttpListenerResponseHelper.GetStatusDescription(value);
@@ -140,20 +144,26 @@ namespace EmbedIO.Net.Internal
 
         public void Close()
         {
-            if (!_disposed) Close(false);
+            if (!_disposed)
+            {
+                Close(false);
+            }
         }
 
         /// <inheritdoc />
         public void SetCookie(Cookie cookie)
         {
             if (cookie == null)
+            {
                 throw new ArgumentNullException(nameof(cookie));
+            }
 
             if (_cookies != null)
             {
-                if (_cookies.Any(c =>
-                    cookie.Name == c.Name && cookie.Domain == c.Domain && cookie.Path == c.Path))
+                if (_cookies.Any(c => cookie.Name == c.Name && cookie.Domain == c.Domain && cookie.Path == c.Path))
+                {
                     throw new ArgumentException("The cookie already exists.");
+                }
             }
             else
             {
@@ -175,10 +185,14 @@ namespace EmbedIO.Net.Internal
             }
 
             if (Headers[HttpHeaderNames.Server] == null)
+            {
                 Headers.Add(HttpHeaderNames.Server, WebServer.Signature);
+            }
 
             if (Headers[HttpHeaderNames.Date] == null)
+            {
                 Headers.Add(HttpHeaderNames.Date, HttpDate.Format(DateTime.UtcNow));
+            }
 
             if (closing)
             {
@@ -188,23 +202,29 @@ namespace EmbedIO.Net.Internal
             else
             {
                 if (ProtocolVersion < HttpVersion.Version11)
+                {
                     _chunked = false;
+                }
 
                 var haveContentLength = !_chunked
-                                 && Headers.ContainsKey(HttpHeaderNames.ContentLength)
-                                 && long.TryParse(Headers[HttpHeaderNames.ContentLength], out var contentLength)
-                                 && contentLength >= 0L;
+                                     && Headers.ContainsKey(HttpHeaderNames.ContentLength)
+                                     && long.TryParse(Headers[HttpHeaderNames.ContentLength], out var contentLength)
+                                     && contentLength >= 0L;
             
                 if (!haveContentLength)
                 {
                     Headers.Remove(HttpHeaderNames.ContentLength);
                     if (ProtocolVersion >= HttpVersion.Version11)
+                    {
                         _chunked = true;
+                    }
                 }
             }
 
             if (_chunked)
+            {
                 Headers.Add(HttpHeaderNames.TransferEncoding, "chunked");
+            }
 
             //// Apache forces closing the connection for these status codes:
             //// HttpStatusCode.BadRequest            400
@@ -231,7 +251,9 @@ namespace EmbedIO.Net.Internal
             {
                 Headers.Add(HttpHeaderNames.Connection, "keep-alive");
                 if (ProtocolVersion >= HttpVersion.Version11)
+                {
                     Headers.Add(HttpHeaderNames.KeepAlive, $"timeout=15,max={100 - reuses}");
+                }
             }
             else
             {
@@ -244,12 +266,16 @@ namespace EmbedIO.Net.Internal
         private static void AppendSetCookieHeader(StringBuilder sb, Cookie cookie)
         {
             if (cookie.Name.Length == 0)
+            {
                 return;
+            }
 
             _ = sb.Append("Set-Cookie: ");
 
             if (cookie.Version > 0)
+            {
                 _ = sb.Append("Version=").Append(cookie.Version).Append("; ");
+            }
 
             _ = sb
                 .Append(cookie.Name)
@@ -264,19 +290,29 @@ namespace EmbedIO.Net.Internal
             }
 
             if (!string.IsNullOrEmpty(cookie.Path))
+            {
                 _ = sb.Append("; Path=").Append(QuotedString(cookie, cookie.Path));
+            }
 
             if (!string.IsNullOrEmpty(cookie.Domain))
+            {
                 _ = sb.Append("; Domain=").Append(QuotedString(cookie, cookie.Domain));
+            }
 
             if (!string.IsNullOrEmpty(cookie.Port))
+            {
                 _ = sb.Append("; Port=").Append(cookie.Port);
+            }
 
             if (cookie.Secure)
+            {
                 _ = sb.Append("; Secure");
+            }
 
             if (cookie.HttpOnly)
+            {
                 _ = sb.Append("; HttpOnly");
+            }
 
             _ = sb.Append("\r\n");
         }
@@ -314,13 +350,17 @@ namespace EmbedIO.Net.Internal
             if (_cookies != null)
             {
                 foreach (var cookie in _cookies)
+                {
                     AppendSetCookieHeader(sb, cookie);
+                }
             }
 
             if (Headers.ContainsKey(HttpHeaderNames.SetCookie))
             {
                 foreach (var cookie in CookieList.Parse(Headers[HttpHeaderNames.SetCookie]))
+                {
                     AppendSetCookieHeader(sb, cookie);
+                }
             }
 
             return sb.Append("\r\n").ToString();
@@ -347,10 +387,14 @@ namespace EmbedIO.Net.Internal
         private void EnsureCanChangeHeaders()
         {
             if (_disposed)
+            {
                 throw new ObjectDisposedException(_id);
+            }
 
             if (HeadersSent)
+            {
                 throw new InvalidOperationException("Header values cannot be changed after headers are sent.");
+            }
         }
     }
 }

--- a/src/EmbedIO/Net/Internal/HttpListenerResponse.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerResponse.cs
@@ -374,8 +374,7 @@ namespace EmbedIO.Net.Internal
             stream.Write(preamble, 0, preamble.Length);
             stream.Write(data, 0, data.Length);
 
-            if (_outputStream == null)
-                _outputStream = _connection.GetResponseStream();
+            _outputStream ??= _connection.GetResponseStream();
 
             // Assumes that the ms was at position 0
             stream.Position = preamble.Length;

--- a/src/EmbedIO/Net/Internal/HttpListenerResponse.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerResponse.cs
@@ -279,7 +279,7 @@ namespace EmbedIO.Net.Internal
 
             _ = sb
                 .Append(cookie.Name)
-                .Append("=")
+                .Append('=')
                 .Append(cookie.Value);
 
             if (cookie.Expires != DateTime.MinValue)

--- a/src/EmbedIO/Net/Internal/HttpListenerResponse.cs
+++ b/src/EmbedIO/Net/Internal/HttpListenerResponse.cs
@@ -15,6 +15,7 @@ namespace EmbedIO.Net.Internal
     internal sealed class HttpListenerResponse : IHttpResponse, IDisposable
     {
         private readonly HttpConnection _connection;
+        private readonly HttpListenerRequest _request;
         private readonly string _id;
         private bool _disposed;
         private string _contentType = MimeType.Html; // Same default value as Microsoft's implementation
@@ -26,10 +27,10 @@ namespace EmbedIO.Net.Internal
 
         internal HttpListenerResponse(HttpListenerContext context)
         {
+            _request = context.HttpListenerRequest;
             _connection = context.Connection;
             _id = context.Id;
             _keepAlive = context.Request.KeepAlive;
-            ProtocolVersion = context.Request.ProtocolVersion;
         }
 
         /// <inheritdoc />
@@ -90,7 +91,7 @@ namespace EmbedIO.Net.Internal
         public Stream OutputStream => _outputStream ??= _connection.GetResponseStream();
 
         /// <inheritdoc />
-        public Version ProtocolVersion { get; }
+        public Version ProtocolVersion => _request.ProtocolVersion;
 
         /// <inheritdoc />
         /// <exception cref="ObjectDisposedException">This instance has been disposed.</exception>

--- a/src/EmbedIO/Net/Internal/ListenerPrefix.cs
+++ b/src/EmbedIO/Net/Internal/ListenerPrefix.cs
@@ -9,7 +9,7 @@ namespace EmbedIO.Net.Internal
         {
             var defaultPort = 80;
 
-            if (uri.StartsWith("https://"))
+            if (uri.StartsWith("https://", StringComparison.Ordinal))
             {
                 defaultPort = 443;
                 Secure = true;
@@ -64,7 +64,7 @@ namespace EmbedIO.Net.Internal
                 throw new ArgumentNullException(nameof(uri));
             }
 
-            if (!uri.StartsWith("http://") && !uri.StartsWith("https://"))
+            if (!uri.StartsWith("http://", StringComparison.Ordinal) && !uri.StartsWith("https://", StringComparison.Ordinal))
             {
                 throw new ArgumentException("Only 'http' and 'https' schemes are supported.");
             }

--- a/src/EmbedIO/Net/Internal/ListenerPrefix.cs
+++ b/src/EmbedIO/Net/Internal/ListenerPrefix.cs
@@ -19,7 +19,9 @@ namespace EmbedIO.Net.Internal
             var startHost = uri.IndexOf(':') + 3;
 
             if (startHost >= length)
+            {
                 throw new ArgumentException("No host specified.");
+            }
 
             var colon = uri.LastIndexOf(':');
             int root;
@@ -40,7 +42,9 @@ namespace EmbedIO.Net.Internal
             Path = uri.Substring(root);
 
             if (Path.Length != 1)
+            {
                 Path = Path.Substring(0, Path.Length - 1);
+            }
         }
 
         public HttpListener? Listener { get; set; }
@@ -56,41 +60,57 @@ namespace EmbedIO.Net.Internal
         public static void CheckUri(string uri)
         {
             if (uri == null)
+            {
                 throw new ArgumentNullException(nameof(uri));
+            }
 
             if (!uri.StartsWith("http://") && !uri.StartsWith("https://"))
+            {
                 throw new ArgumentException("Only 'http' and 'https' schemes are supported.");
+            }
 
             var length = uri.Length;
             var startHost = uri.IndexOf(':') + 3;
 
             if (startHost >= length)
+            {
                 throw new ArgumentException("No host specified.");
+            }
 
             var colon = uri.Substring(startHost).IndexOf(':') > 0 ? uri.LastIndexOf(':') : -1;
 
             if (startHost == colon)
+            {
                 throw new ArgumentException("No host specified.");
+            }
 
             int root;
             if (colon > 0)
             {
                 root = uri.IndexOf('/', colon, length - colon);
                 if (root == -1)
+                {
                     throw new ArgumentException("No path specified.");
+                }
 
                 if (!int.TryParse(uri.Substring(colon + 1, root - colon - 1), out var p) || p <= 0 || p >= 65536)
+                {
                     throw new ArgumentException("Invalid port.");
+                }
             }
             else
             {
                 root = uri.IndexOf('/', startHost, length - startHost);
                 if (root == -1)
+                {
                     throw new ArgumentException("No path specified.");
+                }
             }
 
             if (uri[uri.Length - 1] != '/')
+            {
                 throw new ArgumentException("The prefix must end with '/'");
+            }
         }
 
         public bool IsValid() => Path.IndexOf('%') == -1 && Path.IndexOf("//", StringComparison.Ordinal) == -1;

--- a/src/EmbedIO/Net/Internal/NetExtensions.cs
+++ b/src/EmbedIO/Net/Internal/NetExtensions.cs
@@ -13,7 +13,9 @@ namespace EmbedIO.Net.Internal
         {
             var bytes = BitConverter.GetBytes(value);
             if (!order.IsHostOrder())
+            {
                 Array.Reverse(bytes);
+            }
 
             return bytes;
         }
@@ -22,7 +24,9 @@ namespace EmbedIO.Net.Internal
         {
             var bytes = BitConverter.GetBytes(value);
             if (!order.IsHostOrder())
+            {
                 Array.Reverse(bytes);
+            }
 
             return bytes;
         }

--- a/src/EmbedIO/Net/Internal/NetExtensions.cs
+++ b/src/EmbedIO/Net/Internal/NetExtensions.cs
@@ -32,18 +32,13 @@ namespace EmbedIO.Net.Internal
         }
         
         internal static byte[] ToHostOrder(this byte[] source, Endianness sourceOrder)
-        {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
+            => source.Length < 1 ? source 
+            : sourceOrder.IsHostOrder() ? source
+            : source.Reverse().ToArray();
 
-            return source.Length > 1 && !sourceOrder.IsHostOrder() ? source.Reverse().ToArray() : source;
-        }
-        
-        internal static bool IsHostOrder(this Endianness order)
-        {
-            // true: !(true ^ true) or !(false ^ false)
-            // false: !(true ^ false) or !(false ^ true)
-            return !(BitConverter.IsLittleEndian ^ (order == Endianness.Little));
-        }
+        // true: !(true ^ true) or !(false ^ false)
+        // false: !(true ^ false) or !(false ^ true)
+        private static bool IsHostOrder(this Endianness order)
+            => !(BitConverter.IsLittleEndian ^ (order == Endianness.Little));
     }
 }

--- a/src/EmbedIO/Net/Internal/RequestStream.cs
+++ b/src/EmbedIO/Net/Internal/RequestStream.cs
@@ -58,7 +58,9 @@ namespace EmbedIO.Net.Internal
             nread = _stream.Read(buffer, offset, count);
 
             if (nread > 0 && _remainingBody > 0)
+            {
                 _remainingBody -= nread;
+            }
 
             return nread;
         }
@@ -75,28 +77,47 @@ namespace EmbedIO.Net.Internal
         private int FillFromBuffer(byte[] buffer, int off, int count)
         {
             if (buffer == null)
+            {
                 throw new ArgumentNullException(nameof(buffer));
+            }
+
             if (off < 0)
+            {
                 throw new ArgumentOutOfRangeException(nameof(off), "< 0");
+            }
+
             if (count < 0)
+            {
                 throw new ArgumentOutOfRangeException(nameof(count), "< 0");
+            }
 
             var len = buffer.Length;
 
             if (off > len)
+            {
                 throw new ArgumentException("destination offset is beyond array size");
+            }
+
             if (off > len - count)
+            {
                 throw new ArgumentException("Reading would overrun buffer");
+            }
 
             if (_remainingBody == 0)
+            {
                 return -1;
+            }
 
             if (_length == 0)
+            {
                 return 0;
+            }
 
             var size = Math.Min(_length, count);
             if (_remainingBody > 0)
+            {
                 size = (int) Math.Min(size, _remainingBody);
+            }
 
             if (_offset > _buffer.Length - size)
             {
@@ -104,13 +125,18 @@ namespace EmbedIO.Net.Internal
             }
 
             if (size == 0)
+            {
                 return 0;
+            }
 
             Buffer.BlockCopy(_buffer, _offset, buffer, off, size);
             _offset += size;
             _length -= size;
             if (_remainingBody > 0)
+            {
                 _remainingBody -= size;
+            }
+
             return size;
         }
     }

--- a/src/EmbedIO/Net/Internal/ResponseStream.cs
+++ b/src/EmbedIO/Net/Internal/ResponseStream.cs
@@ -8,7 +8,7 @@ namespace EmbedIO.Net.Internal
     internal class ResponseStream : Stream
     {
         private static readonly byte[] CrLf = { 13, 10 };
-        private readonly object _headersSyncRoot = new object();
+        private readonly object _headersSyncRoot = new ();
 
         private readonly Stream _stream;
         private readonly HttpListenerResponse _response;

--- a/src/EmbedIO/Net/Internal/ResponseStream.cs
+++ b/src/EmbedIO/Net/Internal/ResponseStream.cs
@@ -51,7 +51,9 @@ namespace EmbedIO.Net.Internal
         public override void Write(byte[] buffer, int offset, int count)
         {
             if (_disposed)
+            {
                 throw new ObjectDisposedException(nameof(ResponseStream));
+            }
 
             byte[] bytes;
             var ms = GetHeaders(false);
@@ -82,10 +84,14 @@ namespace EmbedIO.Net.Internal
             }
 
             if (count > 0)
+            {
                 InternalWrite(buffer, offset, count);
+            }
 
             if (chunked)
+            {
                 InternalWrite(CrLf, 0, 2);
+            }
         }
 
         /// <inheritdoc />
@@ -118,11 +124,17 @@ namespace EmbedIO.Net.Internal
 
         protected override void Dispose(bool disposing)
         {
-            if (_disposed) return;
+            if (_disposed)
+            {
+                return;
+            }
 
             _disposed = true;
 
-            if (!disposing) return;
+            if (!disposing)
+            {
+                return;
+            }
 
             using var ms = GetHeaders(true);
             var chunked = _response.SendChunked;
@@ -170,7 +182,9 @@ namespace EmbedIO.Net.Internal
         private MemoryStream? GetHeaders(bool closing)
         {
             lock (_headersSyncRoot)
+            {
                 return _response.HeadersSent ? null : _response.SendHeaders(closing);
+            }
         }
     }
 }

--- a/src/EmbedIO/Net/Internal/StringExtensions.cs
+++ b/src/EmbedIO/Net/Internal/StringExtensions.cs
@@ -26,14 +26,20 @@ namespace EmbedIO.Net.Internal
                 if (c == '"')
                 {
                     if (escaped)
+                    {
                         escaped = false;
+                    }
                     else
+                    {
                         quoted = !quoted;
+                    }
                 }
                 else if (c == '\\')
                 {
                     if (i < len - 1 && @this[i + 1] == '"')
+                    {
                         escaped = true;
+                    }
                 }
                 else if (c == ',' || (useCookieSeparators && c == ';'))
                 {
@@ -50,7 +56,9 @@ namespace EmbedIO.Net.Internal
             }
 
             if (buff.Length > 0)
+            {
                 yield return buff.ToString();
+            }
         }
 
         internal static string Unquote(this string str)
@@ -59,7 +67,9 @@ namespace EmbedIO.Net.Internal
             var end = str.LastIndexOf('\"');
 
             if (start >= 0 && end >= 0)
+            {
                 str = str.Substring(start + 1, end - 1);
+            }
 
             return str.Trim();
         }

--- a/src/EmbedIO/Net/Internal/StringExtensions.cs
+++ b/src/EmbedIO/Net/Internal/StringExtensions.cs
@@ -46,7 +46,7 @@ namespace EmbedIO.Net.Internal
                     }
                 }
 
-                buff.Append(c);
+                _ = buff.Append(c);
             }
 
             if (buff.Length > 0)

--- a/src/EmbedIO/Net/Internal/SystemHttpContext.cs
+++ b/src/EmbedIO/Net/Internal/SystemHttpContext.cs
@@ -74,7 +74,9 @@ namespace EmbedIO.Net.Internal
         public void OnClose(Action<IHttpContext> callback)
         {
             if (_closed)
+            {
                 throw new InvalidOperationException("HTTP context has already been closed.");
+            }
 
             _closeCallbacks.Push(Validate.NotNull(nameof(callback), callback));
         }

--- a/src/EmbedIO/Net/Internal/SystemHttpContext.cs
+++ b/src/EmbedIO/Net/Internal/SystemHttpContext.cs
@@ -19,9 +19,9 @@ namespace EmbedIO.Net.Internal
     {
         private readonly System.Net.HttpListenerContext _context;
 
-        private readonly TimeKeeper _ageKeeper = new TimeKeeper();
+        private readonly TimeKeeper _ageKeeper = new ();
 
-        private readonly Stack<Action<IHttpContext>> _closeCallbacks = new Stack<Action<IHttpContext>>();
+        private readonly Stack<Action<IHttpContext>> _closeCallbacks = new ();
 
         private bool _closed;
 

--- a/src/EmbedIO/Net/Internal/SystemHttpRequest.cs
+++ b/src/EmbedIO/Net/Internal/SystemHttpRequest.cs
@@ -24,8 +24,8 @@ namespace EmbedIO.Net.Internal
             _ = Enum.TryParse<HttpVerbs>(_request.HttpMethod.Trim(), true, out var verb);
             HttpVerb = verb;
             Cookies = new SystemCookieCollection(_request.Cookies);
-            LocalEndPoint = _request.LocalEndPoint;
-            RemoteEndPoint = _request.RemoteEndPoint;
+            LocalEndPoint = _request.LocalEndPoint!;
+            RemoteEndPoint = _request.RemoteEndPoint!;
         }
 
         /// <inheritdoc />

--- a/src/EmbedIO/Net/Internal/SystemHttpRequest.cs
+++ b/src/EmbedIO/Net/Internal/SystemHttpRequest.cs
@@ -116,6 +116,6 @@ namespace EmbedIO.Net.Internal
         public bool IsAuthenticated => _request.IsAuthenticated;
 
         /// <inheritdoc />
-        public Uri UrlReferrer => _request.UrlReferrer;
+        public Uri? UrlReferrer => _request.UrlReferrer;
     }
 }

--- a/src/EmbedIO/Net/Internal/SystemHttpRequest.cs
+++ b/src/EmbedIO/Net/Internal/SystemHttpRequest.cs
@@ -21,7 +21,7 @@ namespace EmbedIO.Net.Internal
         public SystemHttpRequest(System.Net.HttpListenerContext context)
         {
             _request = context.Request;
-            Enum.TryParse<HttpVerbs>(_request.HttpMethod.Trim(), true, out var verb);
+            _ = Enum.TryParse<HttpVerbs>(_request.HttpMethod.Trim(), true, out var verb);
             HttpVerb = verb;
             Cookies = new SystemCookieCollection(_request.Cookies);
             LocalEndPoint = _request.LocalEndPoint;

--- a/src/EmbedIO/Net/Internal/WebSocketHandshakeResponse.cs
+++ b/src/EmbedIO/Net/Internal/WebSocketHandshakeResponse.cs
@@ -22,7 +22,9 @@ namespace EmbedIO.Net.Internal
             Headers[HttpHeaderNames.Connection] = "Upgrade";
 
             foreach (var cookie in context.Request.Cookies)
+            {
                 Headers.Add("Set-Cookie", cookie.ToString());
+            }
         }
 
         public string Reason { get; }
@@ -39,7 +41,9 @@ namespace EmbedIO.Net.Internal
                 .AppendFormat(CultureInfo.InvariantCulture, "HTTP/{0} {1} {2}\r\n", ProtocolVersion, StatusCode, Reason);
 
             foreach (var key in Headers.AllKeys)
+            {
                 _ = output.AppendFormat(CultureInfo.InvariantCulture, "{0}: {1}\r\n", key, Headers[key]);
+            }
 
             _ = output.Append("\r\n");
             

--- a/src/EmbedIO/Net/Internal/WebSocketHandshakeResponse.cs
+++ b/src/EmbedIO/Net/Internal/WebSocketHandshakeResponse.cs
@@ -39,9 +39,9 @@ namespace EmbedIO.Net.Internal
                 .AppendFormat(CultureInfo.InvariantCulture, "HTTP/{0} {1} {2}\r\n", ProtocolVersion, StatusCode, Reason);
 
             foreach (var key in Headers.AllKeys)
-                output.AppendFormat(CultureInfo.InvariantCulture, "{0}: {1}\r\n", key, Headers[key]);
+                _ = output.AppendFormat(CultureInfo.InvariantCulture, "{0}: {1}\r\n", key, Headers[key]);
 
-            output.Append("\r\n");
+            _ = output.Append("\r\n");
             
             return output.ToString();
         }

--- a/src/EmbedIO/WebServer-Constants.cs
+++ b/src/EmbedIO/WebServer-Constants.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -14,6 +15,11 @@ namespace EmbedIO
         /// <see href="https://referencesource.microsoft.com/#mscorlib/system/io/stream.cs,50">.NET Framework reference source</see>.</para>
         /// </summary>
         public const int StreamCopyBufferSize = 81920;
+
+        /// <summary>
+        /// <para>The scheme of <see cref="NullUri"/>.</para>
+        /// </summary>
+        public const string UriSchemeNull = "null";
 
         /// <summary>
         /// The signature string included in <c>Server</c> response headers.
@@ -33,5 +39,11 @@ namespace EmbedIO
         /// <para>This is the same as <see cref="Utf8NoBomEncoding"/>.</para>
         /// </summary>
         public static readonly Encoding DefaultEncoding = Utf8NoBomEncoding;
+
+        /// <summary>
+        /// <para>An <see cref="Uri"/> which cannot be equal to any HTTP / HTTP URI.</para>
+        /// <para>Used as the default value for non-nullable properties of type <see cref="Uri"/>.</para>
+        /// </summary>
+        public static readonly Uri NullUri = new ("null:");
     }
 }

--- a/src/EmbedIO/WebSockets/Internal/WebSocket.cs
+++ b/src/EmbedIO/WebSockets/Internal/WebSocket.cs
@@ -23,8 +23,8 @@ namespace EmbedIO.WebSockets.Internal
     {
         public const string SupportedVersion = "13";
         
-        private readonly object _stateSyncRoot = new object();
-        private readonly ConcurrentQueue<MessageEventArgs> _messageEventQueue = new ConcurrentQueue<MessageEventArgs>();
+        private readonly object _stateSyncRoot = new ();
+        private readonly ConcurrentQueue<MessageEventArgs> _messageEventQueue = new ();
         private readonly Action _closeConnection;
         private readonly TimeSpan _waitTime = TimeSpan.FromSeconds(1);
 

--- a/src/EmbedIO/WebSockets/Internal/WebSocketFrame.cs
+++ b/src/EmbedIO/WebSockets/Internal/WebSocketFrame.cs
@@ -139,10 +139,14 @@ Extended Payload Length: {extPayloadLen}
             buff.Write(((ushort)header).ToByteArray(Endianness.Big), 0, 2);
 
             if (PayloadLength > 125)
+            {
                 buff.Write(ExtendedPayloadLength, 0, PayloadLength == 126 ? 2 : 8);
+            }
 
             if (Mask == Mask.On)
+            {
                 buff.Write(MaskingKey, 0, 4);
+            }
 
             if (PayloadLength > 0)
             {
@@ -172,7 +176,9 @@ Extended Payload Length: {extPayloadLen}
         internal void Validate(WebSocket webSocket)
         {
             if (!IsMasked)
+            {
                 throw new WebSocketException(CloseStatusCode.ProtocolError, "A frame from a client isn't masked.");
+            }
 
             if (webSocket.InContinuation && (Opcode == Opcode.Text || Opcode == Opcode.Binary))
             {
@@ -202,7 +208,9 @@ Extended Payload Length: {extPayloadLen}
         internal void Unmask()
         {
             if (Mask == Mask.Off)
+            {
                 return;
+            }
 
             Mask = Mask.Off;
             PayloadData.Mask(MaskingKey);

--- a/src/EmbedIO/WebSockets/Internal/WebSocketFrame.cs
+++ b/src/EmbedIO/WebSockets/Internal/WebSocketFrame.cs
@@ -22,7 +22,10 @@ namespace EmbedIO.WebSockets.Internal
         }
 
         internal WebSocketFrame(
-            Fin fin, Opcode opcode, PayloadData payloadData, bool compressed = false)
+            Fin fin,
+            Opcode opcode,
+            PayloadData payloadData,
+            bool compressed = false)
         {
             Fin = fin;
             Rsv1 = IsOpcodeData(opcode) && compressed ? Rsv.On : Rsv.Off;

--- a/src/EmbedIO/WebSockets/Internal/WebSocketFrame.cs
+++ b/src/EmbedIO/WebSockets/Internal/WebSocketFrame.cs
@@ -167,11 +167,11 @@ Extended Payload Length: {extPayloadLen}
 
         public override string ToString() => BitConverter.ToString(ToArray());
 
-        internal static WebSocketFrame CreateCloseFrame(PayloadData? payloadData) => new WebSocketFrame(Fin.Final, Opcode.Close, payloadData ?? new PayloadData());
+        internal static WebSocketFrame CreateCloseFrame(PayloadData? payloadData) => new (Fin.Final, Opcode.Close, payloadData ?? new PayloadData());
 
-        internal static WebSocketFrame CreatePingFrame() => new WebSocketFrame(Fin.Final, Opcode.Ping, new PayloadData());
+        internal static WebSocketFrame CreatePingFrame() => new (Fin.Final, Opcode.Ping, new PayloadData());
 
-        internal static WebSocketFrame CreatePingFrame(byte[] data) => new WebSocketFrame(Fin.Final, Opcode.Ping, new PayloadData(data));
+        internal static WebSocketFrame CreatePingFrame(byte[] data) => new (Fin.Final, Opcode.Ping, new PayloadData(data));
 
         internal void Validate(WebSocket webSocket)
         {

--- a/src/EmbedIO/WebSockets/Internal/WebSocketFrame.cs
+++ b/src/EmbedIO/WebSockets/Internal/WebSocketFrame.cs
@@ -55,8 +55,22 @@ namespace EmbedIO.WebSockets.Internal
             PayloadData = payloadData;
         }
 
-        internal WebSocketFrame()
+        internal WebSocketFrame(
+            Fin fin,
+            Rsv rsv1,
+            Rsv rsv2,
+            Rsv rsv3,
+            Opcode opcode,
+            Mask mask,
+            byte payloadLength)
         {
+            Fin = fin;
+            Rsv1 = rsv1;
+            Rsv2 = rsv2;
+            Rsv3 = rsv3;
+            Opcode = opcode;
+            Mask = mask;
+            PayloadLength = payloadLength;
         }
 
         public byte[]? ExtendedPayloadLength { get; internal set; }

--- a/src/EmbedIO/WebSockets/Internal/WebSocketFrameStream.cs
+++ b/src/EmbedIO/WebSockets/Internal/WebSocketFrameStream.cs
@@ -66,15 +66,11 @@ namespace EmbedIO.WebSockets.Internal
             // Payload Length
             var payloadLen = (byte)(header[1] & 0x7f);
 
-            var err = !Enum.IsDefined(typeof(Opcode), opcode)
-                ? "An unsupported opcode."
-                : !IsOpcodeData(opcode) && rsv1 == Rsv.On
-                    ? "A non data frame is compressed."
-                    : IsOpcodeControl(opcode) && fin == Fin.More
-                        ? "A control frame is fragmented."
-                        : IsOpcodeControl(opcode) && payloadLen > 125
-                            ? "A control frame has a long payload length."
-                            : null;
+            var err = !Enum.IsDefined(typeof(Opcode), opcode) ? "An unsupported opcode."
+            : !IsOpcodeData(opcode) && rsv1 == Rsv.On ? "A non data frame is compressed."
+            : IsOpcodeControl(opcode) && fin == Fin.More ? "A control frame is fragmented."
+            : IsOpcodeControl(opcode) && payloadLen > 125 ? "A control frame has a long payload length."
+            : null;
 
             if (err != null)
                 throw new WebSocketException(CloseStatusCode.ProtocolError, err);

--- a/src/EmbedIO/WebSockets/Internal/WebSocketFrameStream.cs
+++ b/src/EmbedIO/WebSockets/Internal/WebSocketFrameStream.cs
@@ -75,16 +75,7 @@ namespace EmbedIO.WebSockets.Internal
             if (err != null)
                 throw new WebSocketException(CloseStatusCode.ProtocolError, err);
 
-            return new WebSocketFrame
-            {
-                Fin = fin,
-                Rsv1 = rsv1,
-                Rsv2 = rsv2,
-                Rsv3 = rsv3,
-                Opcode = (Opcode)opcode,
-                Mask = mask,
-                PayloadLength = payloadLen,
-            };
+            return new WebSocketFrame(fin, rsv1, rsv2, rsv3, (Opcode)opcode, mask, payloadLen);
         }
         
         private async Task ReadExtendedPayloadLengthAsync(WebSocketFrame frame)


### PR DESCRIPTION
HttpListener and WebSockets code has been in bad need of revision for quite some time. This PR improves code style and fixed some of the easiest issues.

(Don't get me wrong: it's still ugly as hell. Now it just looks a little more like C# and a little less like C on Arduino.)

This PR also closes #510 by having HttpListenerResponse.ProtocolVersion mirror the associated request's ProtocolVersion.
