### PR TITLE
Always add WWW-Authenticate header

### DIFF
--- a/src/EmbedIO/Authentication/BasicAuthenticationModuleBase.cs
+++ b/src/EmbedIO/Authentication/BasicAuthenticationModuleBase.cs
@@ -56,10 +56,10 @@ namespace EmbedIO.Authentication
                 }
             }
 
+            context.Response.Headers.Set(HttpHeaderNames.WWWAuthenticate, _wwwAuthenticateHeaderValue);
+
             if (!await IsAuthenticatedAsync().ConfigureAwait(false))
                 throw HttpException.Unauthorized();
-
-            context.Response.Headers.Set(HttpHeaderNames.WWWAuthenticate, _wwwAuthenticateHeaderValue);
         }
 
         /// <summary>

--- a/test/EmbedIO.Tests/BasicAuthenticationModuleTest.cs
+++ b/test/EmbedIO.Tests/BasicAuthenticationModuleTest.cs
@@ -30,6 +30,7 @@ namespace EmbedIO.Tests
         {
             var response = await MakeRequest(UserName, Password).ConfigureAwait(false);
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Status Code OK");
+            Assert.AreEqual("Basic realm=\"/\" charset=UTF-8", response.Headers.WwwAuthenticate.ToString());
         }
 
         [Test]
@@ -39,6 +40,7 @@ namespace EmbedIO.Tests
 
             var response = await MakeRequest(UserName, wrongPassword).ConfigureAwait(false);
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Status Code Unauthorized");
+            Assert.AreEqual("Basic realm=\"/\" charset=UTF-8", response.Headers.WwwAuthenticate.ToString());
         }
 
         [Test]
@@ -46,6 +48,7 @@ namespace EmbedIO.Tests
         {
             var response = await MakeRequest(null, null).ConfigureAwait(false);
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Status Code Unauthorized");
+            Assert.AreEqual("Basic realm=\"/\" charset=UTF-8", response.Headers.WwwAuthenticate.ToString());
         }
 
         private Task<HttpResponseMessage> MakeRequest(string? userName, string? password)

--- a/test/EmbedIO.Tests/BasicAuthenticationModuleTest.cs
+++ b/test/EmbedIO.Tests/BasicAuthenticationModuleTest.cs
@@ -30,6 +30,12 @@ namespace EmbedIO.Tests
         {
             var response = await MakeRequest(UserName, Password).ConfigureAwait(false);
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Status Code OK");
+        }
+
+        [Test]
+        public async Task RequestWithValidCredentials_ReturnsValidWWWAuthenticateHeader()
+        {
+            var response = await MakeRequest(UserName, Password).ConfigureAwait(false);
             Assert.AreEqual("Basic realm=\"/\" charset=UTF-8", response.Headers.WwwAuthenticate.ToString());
         }
 
@@ -40,6 +46,14 @@ namespace EmbedIO.Tests
 
             var response = await MakeRequest(UserName, wrongPassword).ConfigureAwait(false);
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Status Code Unauthorized");
+        }
+
+        [Test]
+        public async Task RequestWithInvalidCredentials_ReturnsValidWWWAuthenticateHeader()
+        {
+            const string wrongPassword = "wrongpaassword";
+
+            var response = await MakeRequest(UserName, wrongPassword).ConfigureAwait(false);
             Assert.AreEqual("Basic realm=\"/\" charset=UTF-8", response.Headers.WwwAuthenticate.ToString());
         }
 
@@ -48,6 +62,12 @@ namespace EmbedIO.Tests
         {
             var response = await MakeRequest(null, null).ConfigureAwait(false);
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Status Code Unauthorized");
+        }
+
+        [Test]
+        public async Task RequestWithNoAuthorizationHeader_ReturnsValidWWWAuthenticateHeader()
+        {
+            var response = await MakeRequest(null, null).ConfigureAwait(false);
             Assert.AreEqual("Basic realm=\"/\" charset=UTF-8", response.Headers.WwwAuthenticate.ToString());
         }
 


### PR DESCRIPTION
WWWAuthenticate header should be added to the answer, even if it's a 401. This way a browser can show the user/password form.