### PR TITLE
Add WWW-Authenticate header to 401 responses

### DIFF
--- a/src/packages/EmbedIO/Authentication/BasicAuthenticationModuleBase.cs
+++ b/src/packages/EmbedIO/Authentication/BasicAuthenticationModuleBase.cs
@@ -50,6 +50,8 @@ namespace EmbedIO.Authentication
         /// <inheritdoc />
         protected sealed override async Task<IPrincipal> AuthenticateAsync([ValidatedNotNull] IHttpContext context)
         {
+			context.Response.Headers.Set(HttpHeaderNames.WWWAuthenticate, _wwwAuthenticateHeaderValue);
+			
             var authHeader = context.Request.Headers[HttpHeaderNames.Authorization];
             if (authHeader == null || !authHeader.StartsWith("basic ", StringComparison.OrdinalIgnoreCase))
                 return Auth.NoUser;

--- a/src/tests/EmbedIO.Tests/BasicAuthenticationModuleTest.cs
+++ b/src/tests/EmbedIO.Tests/BasicAuthenticationModuleTest.cs
@@ -33,6 +33,13 @@ namespace EmbedIO.Tests
         }
 
         [Test]
+        public async Task RequestWithValidCredentials_ReturnsValidWWWAuthenticateHeader()
+        {
+            var response = await MakeRequest(UserName, Password).ConfigureAwait(false);
+            Assert.AreEqual("Basic realm=\"/\" charset=UTF-8", response.Headers.WwwAuthenticate.ToString());
+        }
+
+        [Test]
         public async Task RequestWithInvalidCredentials_ReturnsUnauthorized()
         {
             const string wrongPassword = "wrongpaassword";
@@ -42,10 +49,26 @@ namespace EmbedIO.Tests
         }
 
         [Test]
+        public async Task RequestWithInvalidCredentials_ReturnsValidWWWAuthenticateHeader()
+        {
+            const string wrongPassword = "wrongpaassword";
+
+            var response = await MakeRequest(UserName, wrongPassword).ConfigureAwait(false);
+            Assert.AreEqual("Basic realm=\"/\" charset=UTF-8", response.Headers.WwwAuthenticate.ToString());
+        }
+
+        [Test]
         public async Task RequestWithNoAuthorizationHeader_ReturnsUnauthorized()
         {
             var response = await MakeRequest(null, null).ConfigureAwait(false);
             Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode, "Status Code Unauthorized");
+        }
+
+        [Test]
+        public async Task RequestWithNoAuthorizationHeader_ReturnsValidWWWAuthenticateHeader()
+        {
+            var response = await MakeRequest(null, null).ConfigureAwait(false);
+            Assert.AreEqual("Basic realm=\"/\" charset=UTF-8", response.Headers.WwwAuthenticate.ToString());
         }
 
         private Task<HttpResponseMessage> MakeRequest(string? userName, string? password)


### PR DESCRIPTION
Fixing issue [https://github.com/unosquare/embedio/issues/516](516) by adding the WWW-Authenticate header to responses.