### PR TITLE
Make Unosquare.Swan.Lite version explicit

### DIFF
--- a/src/EmbedIO/EmbedIO.csproj
+++ b/src/EmbedIO/EmbedIO.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unosquare.Swan.Lite" />
+    <PackageReference Include="Unosquare.Swan.Lite" Version="3.1.0" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
The same fix as #571 but for the master branch.