### PR TITLE
Add LiquidPages middleware information

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Name | Author | Description
 [Microsoft.AspNetCore.Server.EmbedIO](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.EmbedIO/) | Dju  | EmbedIO web server support for ASP.NET Core, as a drop-in replacement for Kestrel
 [SambaFetcher](https://github.com/nddipiazza/SambaFetcher/) | nddipiazza  | A .NET tool to connect a web server with Samba
 [SimpleW](https://stratdev3.github.io/SimpleW/) | stratdev3  | A .NET Core Web Server Library, inspired by EmbedIO
+[LiquidPages](https://www.kinetq.com/docs/open-source-software/liquid-pages) Middleware that can be used with any web server to render liquid templates with EmbedIO support.
 
 ## Special Thanks
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Name | Author | Description
 [Microsoft.AspNetCore.Server.EmbedIO](https://www.nuget.org/packages/Microsoft.AspNetCore.Server.EmbedIO/) | Dju  | EmbedIO web server support for ASP.NET Core, as a drop-in replacement for Kestrel
 [SambaFetcher](https://github.com/nddipiazza/SambaFetcher/) | nddipiazza  | A .NET tool to connect a web server with Samba
 [SimpleW](https://stratdev3.github.io/SimpleW/) | stratdev3  | A .NET Core Web Server Library, inspired by EmbedIO
-[LiquidPages](https://www.kinetq.com/docs/open-source-software/liquid-pages) Middleware that can be used with any web server to render liquid templates with EmbedIO support.
+[LiquidPages](https://www.kinetq.com/docs/open-source-software/liquid-pages) | Kinetq | Middleware that can be used with any web server to render liquid templates with EmbedIO support.
 
 ## Special Thanks
 


### PR DESCRIPTION
I set up a library where routes and liquid templates (along with their assets) could be defined in any C# project within a solution. I was also looking for more of an MVVM approach as apposed to MVC and I wanted to be able to use any web server (I already have a separate package for EmbedIO and there is more to come).

Link to the docs for more details: https://www.kinetq.com/docs/open-source-software/liquid-pages